### PR TITLE
Fix for proxy cross domain problem

### DIFF
--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -20,7 +20,31 @@ module.exports = function(options) {
     return function(req, res, next) {
         if (req.url.indexOf('/__api__/proxy/') === 0 || req.url.indexOf('/proxy/') === 0) {
             var url = decodeURIComponent(req.url.replace('/proxy/', ''));
-            var proxy = request(url);
+            //var proxy = request(url);
+            //DON'T KNOW WHY BUT THIS HAS TO BE DELETED
+            delete req.headers.host;
+
+            var body;
+
+            //AS STATED IN REQUEST DOCUMENTATION, body MUST BE STRING OR ARRAY
+            if(req.headers['content-type']=='application/json') {
+
+                body=JSON.stringify(req.body);
+
+            }else{
+
+                body = Object.keys(req.body).map(function (k) {
+                    return k + '=' + req.body[k]
+                }).join('&');
+
+            }
+
+            var proxy = request({
+                method: req.method
+                , uri: url
+                , body:body
+                ,headers:req.headers
+            });
 
             proxy.on('error', function(error){
                 options.emitter.emit('log', 'Proxy error: url: ' + url, error.code);


### PR DESCRIPTION
Headers wasn't forwarded properly as I could see, and for some reason if host is in header it breaks.
Also, body needs to be ether string or array of strings (not sure for array values).

There is maybe better place to do this fix but I am not nodejs dev so it takes me time to connect everything.

My suggestion, do not place host into headers and leave body in format that is in ajax. I am not sure where this modifications happen, maybe is bug in some other lib.
