### PR TITLE
Fix for object data

### DIFF
--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -32,7 +32,9 @@ module.exports = function(options) {
             var body;
 
             // request requires the body to be of type string or array
-            if(req.headers['content-type']=='application/json') {
+            if (req.headers['content-type'].indexOf('application/json')>=0) {
+                //content type always have encoding, that's why check for index (substring match) 
+                //and not string comparison
 
                 body=JSON.stringify(req.body);
 


### PR DESCRIPTION
I have done few test more, and noticed that if data in ajax is type of object and not string, this "content-length" header needs to be deleted.

Again I am not sure why, but I guess that if content-length is forwarded to request, request lib compares this content-length with new one (the one calculated by it self-request) which maybe is not the same on the end because this content-length if data is type of object is calculated differently in first place, I guess.
