### PR TITLE
Add support for Firefox OS

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -11,6 +11,7 @@ var autoreload = require('./middleware/autoreload'),
     inject = require('./middleware/inject'),
     mstatic = require('./middleware/static'),
     nocache = require('./middleware/nocache'),
+    cors = require('./middleware/cors'),
     zip = require('./middleware/zip'),
     path = require('path'),
     plugins = require('./middleware/cordova/plugins'),
@@ -68,6 +69,9 @@ module.exports = function(options) {
 
     // no-cache header
     app.use(nocache(options));
+
+    // CORS headers
+    app.use(cors());
 
     // sessions require the cookie parser
     app.use(connect.cookieParser());

--- a/lib/middleware/cors.js
+++ b/lib/middleware/cors.js
@@ -1,0 +1,25 @@
+/*!
+ * Module dependencies.
+ */
+
+/**
+ * Cors Middlware.
+ *
+ * Set CORS headers.
+ */
+
+module.exports = function() {
+    return function(req,res, next){
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.setHeader('Access-Control-Request-Method', '*');
+        res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET');
+        res.setHeader('Access-Control-Allow-Headers', '*');
+
+        if (req.method === 'OPTIONS') {
+            res.writeHead(200);
+            res.end();
+        }
+
+        next();
+    };
+};

--- a/lib/middleware/ext/session.js
+++ b/lib/middleware/ext/session.js
@@ -29,6 +29,10 @@ module.exports.device = {
             if (req.session.device.platform === 'android') {
                 req.session.device.version = '3.4.0';
             }
+
+            if (req.session.device.platform === 'firefoxos') {
+                req.session.device.version = '3.6.3';
+            }
         }
     },
     set: function(req, query) {
@@ -71,22 +75,32 @@ module.exports.device = {
             '3.2.0': {
                 'android': false,
                 'ios': true,     // PG App 1.0.0
-                'wp8': true      // PG App 1.0.0
+                'wp8': true,     // PG App 1.0.0
+                'firefoxos': false
             },
             '3.4.0': {
                 'android': true, // PG App 1.0.0
                 'ios': false,
-                'wp8': false
+                'wp8': false,
+                'firefoxos': false
             },
             '3.5.0': {
                 'android': true, // PG App 1.1.0
                 'ios': true,     // PG App 1.1.0
-                'wp8': true      // PG App 1.1.0
+                'wp8': true,     // PG App 1.1.0
+                'firefoxos': false
             },
             '3.5.1': {
                 'android': true, // PG App 1.3.0
                 'ios': false,
-                'wp8': false
+                'wp8': false,
+                'firefoxos': false
+            },
+            '3.6.3': {
+                'android': true,
+                'ios': true,
+                'wp8': true,
+                'firefoxos': true
             }
         };
     }

--- a/lib/middleware/ext/useragent.js
+++ b/lib/middleware/ext/useragent.js
@@ -31,6 +31,7 @@ module.exports.parse = function() {
         android: /Android/i.test(browser) || /Chrome/i.test(browser),
         ios: /Mobile Safari/i.test(browser),
         wp8: /IE Mobile/i.test(browser),
+        firefoxos: /Firefox/i.test(browser) && /Mobile/i.test(browser),
         platform: 'unknown'
     };
 

--- a/res/middleware/cordova/3.6.3/firefoxos/cordova.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/cordova.js
@@ -1,0 +1,1526 @@
+// Platform: firefoxos
+// 3.6.3
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+     http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+;(function() {
+var CORDOVA_JS_BUILD_LABEL = '3.6.3';
+// file: src/scripts/require.js
+
+/*jshint -W079 */
+/*jshint -W020 */
+
+var require,
+    define;
+
+(function () {
+    var modules = {},
+    // Stack of moduleIds currently being built.
+        requireStack = [],
+    // Map of module ID -> index into requireStack of modules currently being built.
+        inProgressModules = {},
+        SEPARATOR = ".";
+
+
+
+    function build(module) {
+        var factory = module.factory,
+            localRequire = function (id) {
+                var resultantId = id;
+                //Its a relative path, so lop off the last portion and add the id (minus "./")
+                if (id.charAt(0) === ".") {
+                    resultantId = module.id.slice(0, module.id.lastIndexOf(SEPARATOR)) + SEPARATOR + id.slice(2);
+                }
+                return require(resultantId);
+            };
+        module.exports = {};
+        delete module.factory;
+        factory(localRequire, module.exports, module);
+        return module.exports;
+    }
+
+    require = function (id) {
+        if (!modules[id]) {
+            throw "module " + id + " not found";
+        } else if (id in inProgressModules) {
+            var cycle = requireStack.slice(inProgressModules[id]).join('->') + '->' + id;
+            throw "Cycle in require graph: " + cycle;
+        }
+        if (modules[id].factory) {
+            try {
+                inProgressModules[id] = requireStack.length;
+                requireStack.push(id);
+                return build(modules[id]);
+            } finally {
+                delete inProgressModules[id];
+                requireStack.pop();
+            }
+        }
+        return modules[id].exports;
+    };
+
+    define = function (id, factory) {
+        if (modules[id]) {
+            throw "module " + id + " already defined";
+        }
+
+        modules[id] = {
+            id: id,
+            factory: factory
+        };
+    };
+
+    define.remove = function (id) {
+        delete modules[id];
+    };
+
+    define.moduleMap = modules;
+})();
+
+//Export for use in node
+if (typeof module === "object" && typeof require === "function") {
+    module.exports.require = require;
+    module.exports.define = define;
+}
+
+// file: src/cordova.js
+define("cordova", function(require, exports, module) {
+
+
+var channel = require('cordova/channel');
+var platform = require('cordova/platform');
+
+/**
+ * Intercept calls to addEventListener + removeEventListener and handle deviceready,
+ * resume, and pause events.
+ */
+var m_document_addEventListener = document.addEventListener;
+var m_document_removeEventListener = document.removeEventListener;
+var m_window_addEventListener = window.addEventListener;
+var m_window_removeEventListener = window.removeEventListener;
+
+/**
+ * Houses custom event handlers to intercept on document + window event listeners.
+ */
+var documentEventHandlers = {},
+    windowEventHandlers = {};
+
+document.addEventListener = function(evt, handler, capture) {
+    var e = evt.toLowerCase();
+    if (typeof documentEventHandlers[e] != 'undefined') {
+        documentEventHandlers[e].subscribe(handler);
+    } else {
+        m_document_addEventListener.call(document, evt, handler, capture);
+    }
+};
+
+window.addEventListener = function(evt, handler, capture) {
+    var e = evt.toLowerCase();
+    if (typeof windowEventHandlers[e] != 'undefined') {
+        windowEventHandlers[e].subscribe(handler);
+    } else {
+        m_window_addEventListener.call(window, evt, handler, capture);
+    }
+};
+
+document.removeEventListener = function(evt, handler, capture) {
+    var e = evt.toLowerCase();
+    // If unsubscribing from an event that is handled by a plugin
+    if (typeof documentEventHandlers[e] != "undefined") {
+        documentEventHandlers[e].unsubscribe(handler);
+    } else {
+        m_document_removeEventListener.call(document, evt, handler, capture);
+    }
+};
+
+window.removeEventListener = function(evt, handler, capture) {
+    var e = evt.toLowerCase();
+    // If unsubscribing from an event that is handled by a plugin
+    if (typeof windowEventHandlers[e] != "undefined") {
+        windowEventHandlers[e].unsubscribe(handler);
+    } else {
+        m_window_removeEventListener.call(window, evt, handler, capture);
+    }
+};
+
+function createEvent(type, data) {
+    var event = document.createEvent('Events');
+    event.initEvent(type, false, false);
+    if (data) {
+        for (var i in data) {
+            if (data.hasOwnProperty(i)) {
+                event[i] = data[i];
+            }
+        }
+    }
+    return event;
+}
+
+
+var cordova = {
+    define:define,
+    require:require,
+    version:CORDOVA_JS_BUILD_LABEL,
+    platformId:platform.id,
+    /**
+     * Methods to add/remove your own addEventListener hijacking on document + window.
+     */
+    addWindowEventHandler:function(event) {
+        return (windowEventHandlers[event] = channel.create(event));
+    },
+    addStickyDocumentEventHandler:function(event) {
+        return (documentEventHandlers[event] = channel.createSticky(event));
+    },
+    addDocumentEventHandler:function(event) {
+        return (documentEventHandlers[event] = channel.create(event));
+    },
+    removeWindowEventHandler:function(event) {
+        delete windowEventHandlers[event];
+    },
+    removeDocumentEventHandler:function(event) {
+        delete documentEventHandlers[event];
+    },
+    /**
+     * Retrieve original event handlers that were replaced by Cordova
+     *
+     * @return object
+     */
+    getOriginalHandlers: function() {
+        return {'document': {'addEventListener': m_document_addEventListener, 'removeEventListener': m_document_removeEventListener},
+        'window': {'addEventListener': m_window_addEventListener, 'removeEventListener': m_window_removeEventListener}};
+    },
+    /**
+     * Method to fire event from native code
+     * bNoDetach is required for events which cause an exception which needs to be caught in native code
+     */
+    fireDocumentEvent: function(type, data, bNoDetach) {
+        var evt = createEvent(type, data);
+        if (typeof documentEventHandlers[type] != 'undefined') {
+            if( bNoDetach ) {
+                documentEventHandlers[type].fire(evt);
+            }
+            else {
+                setTimeout(function() {
+                    // Fire deviceready on listeners that were registered before cordova.js was loaded.
+                    if (type == 'deviceready') {
+                        document.dispatchEvent(evt);
+                    }
+                    documentEventHandlers[type].fire(evt);
+                }, 0);
+            }
+        } else {
+            document.dispatchEvent(evt);
+        }
+    },
+    fireWindowEvent: function(type, data) {
+        var evt = createEvent(type,data);
+        if (typeof windowEventHandlers[type] != 'undefined') {
+            setTimeout(function() {
+                windowEventHandlers[type].fire(evt);
+            }, 0);
+        } else {
+            window.dispatchEvent(evt);
+        }
+    },
+
+    /**
+     * Plugin callback mechanism.
+     */
+    // Randomize the starting callbackId to avoid collisions after refreshing or navigating.
+    // This way, it's very unlikely that any new callback would get the same callbackId as an old callback.
+    callbackId: Math.floor(Math.random() * 2000000000),
+    callbacks:  {},
+    callbackStatus: {
+        NO_RESULT: 0,
+        OK: 1,
+        CLASS_NOT_FOUND_EXCEPTION: 2,
+        ILLEGAL_ACCESS_EXCEPTION: 3,
+        INSTANTIATION_EXCEPTION: 4,
+        MALFORMED_URL_EXCEPTION: 5,
+        IO_EXCEPTION: 6,
+        INVALID_ACTION: 7,
+        JSON_EXCEPTION: 8,
+        ERROR: 9
+    },
+
+    /**
+     * Called by native code when returning successful result from an action.
+     */
+    callbackSuccess: function(callbackId, args) {
+        try {
+            cordova.callbackFromNative(callbackId, true, args.status, [args.message], args.keepCallback);
+        } catch (e) {
+            console.log("Error in success callback: " + callbackId + " = "+e);
+        }
+    },
+
+    /**
+     * Called by native code when returning error result from an action.
+     */
+    callbackError: function(callbackId, args) {
+        // TODO: Deprecate callbackSuccess and callbackError in favour of callbackFromNative.
+        // Derive success from status.
+        try {
+            cordova.callbackFromNative(callbackId, false, args.status, [args.message], args.keepCallback);
+        } catch (e) {
+            console.log("Error in error callback: " + callbackId + " = "+e);
+        }
+    },
+
+    /**
+     * Called by native code when returning the result from an action.
+     */
+    callbackFromNative: function(callbackId, success, status, args, keepCallback) {
+        var callback = cordova.callbacks[callbackId];
+        if (callback) {
+            if (success && status == cordova.callbackStatus.OK) {
+                callback.success && callback.success.apply(null, args);
+            } else if (!success) {
+                callback.fail && callback.fail.apply(null, args);
+            }
+
+            // Clear callback if not expecting any more results
+            if (!keepCallback) {
+                delete cordova.callbacks[callbackId];
+            }
+        }
+    },
+    addConstructor: function(func) {
+        channel.onCordovaReady.subscribe(function() {
+            try {
+                func();
+            } catch(e) {
+                console.log("Failed to run constructor: " + e);
+            }
+        });
+    }
+};
+
+
+module.exports = cordova;
+
+});
+
+// file: src/common/argscheck.js
+define("cordova/argscheck", function(require, exports, module) {
+
+var exec = require('cordova/exec');
+var utils = require('cordova/utils');
+
+var moduleExports = module.exports;
+
+var typeMap = {
+    'A': 'Array',
+    'D': 'Date',
+    'N': 'Number',
+    'S': 'String',
+    'F': 'Function',
+    'O': 'Object'
+};
+
+function extractParamName(callee, argIndex) {
+    return (/.*?\((.*?)\)/).exec(callee)[1].split(', ')[argIndex];
+}
+
+function checkArgs(spec, functionName, args, opt_callee) {
+    if (!moduleExports.enableChecks) {
+        return;
+    }
+    var errMsg = null;
+    var typeName;
+    for (var i = 0; i < spec.length; ++i) {
+        var c = spec.charAt(i),
+            cUpper = c.toUpperCase(),
+            arg = args[i];
+        // Asterix means allow anything.
+        if (c == '*') {
+            continue;
+        }
+        typeName = utils.typeName(arg);
+        if ((arg === null || arg === undefined) && c == cUpper) {
+            continue;
+        }
+        if (typeName != typeMap[cUpper]) {
+            errMsg = 'Expected ' + typeMap[cUpper];
+            break;
+        }
+    }
+    if (errMsg) {
+        errMsg += ', but got ' + typeName + '.';
+        errMsg = 'Wrong type for parameter "' + extractParamName(opt_callee || args.callee, i) + '" of ' + functionName + ': ' + errMsg;
+        // Don't log when running unit tests.
+        if (typeof jasmine == 'undefined') {
+            console.error(errMsg);
+        }
+        throw TypeError(errMsg);
+    }
+}
+
+function getValue(value, defaultValue) {
+    return value === undefined ? defaultValue : value;
+}
+
+moduleExports.checkArgs = checkArgs;
+moduleExports.getValue = getValue;
+moduleExports.enableChecks = true;
+
+
+});
+
+// file: src/common/base64.js
+define("cordova/base64", function(require, exports, module) {
+
+var base64 = exports;
+
+base64.fromArrayBuffer = function(arrayBuffer) {
+    var array = new Uint8Array(arrayBuffer);
+    return uint8ToBase64(array);
+};
+
+base64.toArrayBuffer = function(str) {
+    var decodedStr = typeof atob != 'undefined' ? atob(str) : new Buffer(str,'base64').toString('binary');
+    var arrayBuffer = new ArrayBuffer(decodedStr.length);
+    var array = new Uint8Array(arrayBuffer);
+    for (var i=0, len=decodedStr.length; i < len; i++) {
+        array[i] = decodedStr.charCodeAt(i);
+    }
+    return arrayBuffer;
+};
+
+//------------------------------------------------------------------------------
+
+/* This code is based on the performance tests at http://jsperf.com/b64tests
+ * This 12-bit-at-a-time algorithm was the best performing version on all
+ * platforms tested.
+ */
+
+var b64_6bit = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+var b64_12bit;
+
+var b64_12bitTable = function() {
+    b64_12bit = [];
+    for (var i=0; i<64; i++) {
+        for (var j=0; j<64; j++) {
+            b64_12bit[i*64+j] = b64_6bit[i] + b64_6bit[j];
+        }
+    }
+    b64_12bitTable = function() { return b64_12bit; };
+    return b64_12bit;
+};
+
+function uint8ToBase64(rawData) {
+    var numBytes = rawData.byteLength;
+    var output="";
+    var segment;
+    var table = b64_12bitTable();
+    for (var i=0;i<numBytes-2;i+=3) {
+        segment = (rawData[i] << 16) + (rawData[i+1] << 8) + rawData[i+2];
+        output += table[segment >> 12];
+        output += table[segment & 0xfff];
+    }
+    if (numBytes - i == 2) {
+        segment = (rawData[i] << 16) + (rawData[i+1] << 8);
+        output += table[segment >> 12];
+        output += b64_6bit[(segment & 0xfff) >> 6];
+        output += '=';
+    } else if (numBytes - i == 1) {
+        segment = (rawData[i] << 16);
+        output += table[segment >> 12];
+        output += '==';
+    }
+    return output;
+}
+
+});
+
+// file: src/common/builder.js
+define("cordova/builder", function(require, exports, module) {
+
+var utils = require('cordova/utils');
+
+function each(objects, func, context) {
+    for (var prop in objects) {
+        if (objects.hasOwnProperty(prop)) {
+            func.apply(context, [objects[prop], prop]);
+        }
+    }
+}
+
+function clobber(obj, key, value) {
+    exports.replaceHookForTesting(obj, key);
+    obj[key] = value;
+    // Getters can only be overridden by getters.
+    if (obj[key] !== value) {
+        utils.defineGetter(obj, key, function() {
+            return value;
+        });
+    }
+}
+
+function assignOrWrapInDeprecateGetter(obj, key, value, message) {
+    if (message) {
+        utils.defineGetter(obj, key, function() {
+            console.log(message);
+            delete obj[key];
+            clobber(obj, key, value);
+            return value;
+        });
+    } else {
+        clobber(obj, key, value);
+    }
+}
+
+function include(parent, objects, clobber, merge) {
+    each(objects, function (obj, key) {
+        try {
+            var result = obj.path ? require(obj.path) : {};
+
+            if (clobber) {
+                // Clobber if it doesn't exist.
+                if (typeof parent[key] === 'undefined') {
+                    assignOrWrapInDeprecateGetter(parent, key, result, obj.deprecated);
+                } else if (typeof obj.path !== 'undefined') {
+                    // If merging, merge properties onto parent, otherwise, clobber.
+                    if (merge) {
+                        recursiveMerge(parent[key], result);
+                    } else {
+                        assignOrWrapInDeprecateGetter(parent, key, result, obj.deprecated);
+                    }
+                }
+                result = parent[key];
+            } else {
+                // Overwrite if not currently defined.
+                if (typeof parent[key] == 'undefined') {
+                    assignOrWrapInDeprecateGetter(parent, key, result, obj.deprecated);
+                } else {
+                    // Set result to what already exists, so we can build children into it if they exist.
+                    result = parent[key];
+                }
+            }
+
+            if (obj.children) {
+                include(result, obj.children, clobber, merge);
+            }
+        } catch(e) {
+            utils.alert('Exception building Cordova JS globals: ' + e + ' for key "' + key + '"');
+        }
+    });
+}
+
+/**
+ * Merge properties from one object onto another recursively.  Properties from
+ * the src object will overwrite existing target property.
+ *
+ * @param target Object to merge properties into.
+ * @param src Object to merge properties from.
+ */
+function recursiveMerge(target, src) {
+    for (var prop in src) {
+        if (src.hasOwnProperty(prop)) {
+            if (target.prototype && target.prototype.constructor === target) {
+                // If the target object is a constructor override off prototype.
+                clobber(target.prototype, prop, src[prop]);
+            } else {
+                if (typeof src[prop] === 'object' && typeof target[prop] === 'object') {
+                    recursiveMerge(target[prop], src[prop]);
+                } else {
+                    clobber(target, prop, src[prop]);
+                }
+            }
+        }
+    }
+}
+
+exports.buildIntoButDoNotClobber = function(objects, target) {
+    include(target, objects, false, false);
+};
+exports.buildIntoAndClobber = function(objects, target) {
+    include(target, objects, true, false);
+};
+exports.buildIntoAndMerge = function(objects, target) {
+    include(target, objects, true, true);
+};
+exports.recursiveMerge = recursiveMerge;
+exports.assignOrWrapInDeprecateGetter = assignOrWrapInDeprecateGetter;
+exports.replaceHookForTesting = function() {};
+
+});
+
+// file: src/common/channel.js
+define("cordova/channel", function(require, exports, module) {
+
+var utils = require('cordova/utils'),
+    nextGuid = 1;
+
+/**
+ * Custom pub-sub "channel" that can have functions subscribed to it
+ * This object is used to define and control firing of events for
+ * cordova initialization, as well as for custom events thereafter.
+ *
+ * The order of events during page load and Cordova startup is as follows:
+ *
+ * onDOMContentLoaded*         Internal event that is received when the web page is loaded and parsed.
+ * onNativeReady*              Internal event that indicates the Cordova native side is ready.
+ * onCordovaReady*             Internal event fired when all Cordova JavaScript objects have been created.
+ * onDeviceReady*              User event fired to indicate that Cordova is ready
+ * onResume                    User event fired to indicate a start/resume lifecycle event
+ * onPause                     User event fired to indicate a pause lifecycle event
+ * onDestroy*                  Internal event fired when app is being destroyed (User should use window.onunload event, not this one).
+ *
+ * The events marked with an * are sticky. Once they have fired, they will stay in the fired state.
+ * All listeners that subscribe after the event is fired will be executed right away.
+ *
+ * The only Cordova events that user code should register for are:
+ *      deviceready           Cordova native code is initialized and Cordova APIs can be called from JavaScript
+ *      pause                 App has moved to background
+ *      resume                App has returned to foreground
+ *
+ * Listeners can be registered as:
+ *      document.addEventListener("deviceready", myDeviceReadyListener, false);
+ *      document.addEventListener("resume", myResumeListener, false);
+ *      document.addEventListener("pause", myPauseListener, false);
+ *
+ * The DOM lifecycle events should be used for saving and restoring state
+ *      window.onload
+ *      window.onunload
+ *
+ */
+
+/**
+ * Channel
+ * @constructor
+ * @param type  String the channel name
+ */
+var Channel = function(type, sticky) {
+    this.type = type;
+    // Map of guid -> function.
+    this.handlers = {};
+    // 0 = Non-sticky, 1 = Sticky non-fired, 2 = Sticky fired.
+    this.state = sticky ? 1 : 0;
+    // Used in sticky mode to remember args passed to fire().
+    this.fireArgs = null;
+    // Used by onHasSubscribersChange to know if there are any listeners.
+    this.numHandlers = 0;
+    // Function that is called when the first listener is subscribed, or when
+    // the last listener is unsubscribed.
+    this.onHasSubscribersChange = null;
+},
+    channel = {
+        /**
+         * Calls the provided function only after all of the channels specified
+         * have been fired. All channels must be sticky channels.
+         */
+        join: function(h, c) {
+            var len = c.length,
+                i = len,
+                f = function() {
+                    if (!(--i)) h();
+                };
+            for (var j=0; j<len; j++) {
+                if (c[j].state === 0) {
+                    throw Error('Can only use join with sticky channels.');
+                }
+                c[j].subscribe(f);
+            }
+            if (!len) h();
+        },
+        create: function(type) {
+            return channel[type] = new Channel(type, false);
+        },
+        createSticky: function(type) {
+            return channel[type] = new Channel(type, true);
+        },
+
+        /**
+         * cordova Channels that must fire before "deviceready" is fired.
+         */
+        deviceReadyChannelsArray: [],
+        deviceReadyChannelsMap: {},
+
+        /**
+         * Indicate that a feature needs to be initialized before it is ready to be used.
+         * This holds up Cordova's "deviceready" event until the feature has been initialized
+         * and Cordova.initComplete(feature) is called.
+         *
+         * @param feature {String}     The unique feature name
+         */
+        waitForInitialization: function(feature) {
+            if (feature) {
+                var c = channel[feature] || this.createSticky(feature);
+                this.deviceReadyChannelsMap[feature] = c;
+                this.deviceReadyChannelsArray.push(c);
+            }
+        },
+
+        /**
+         * Indicate that initialization code has completed and the feature is ready to be used.
+         *
+         * @param feature {String}     The unique feature name
+         */
+        initializationComplete: function(feature) {
+            var c = this.deviceReadyChannelsMap[feature];
+            if (c) {
+                c.fire();
+            }
+        }
+    };
+
+function forceFunction(f) {
+    if (typeof f != 'function') throw "Function required as first argument!";
+}
+
+/**
+ * Subscribes the given function to the channel. Any time that
+ * Channel.fire is called so too will the function.
+ * Optionally specify an execution context for the function
+ * and a guid that can be used to stop subscribing to the channel.
+ * Returns the guid.
+ */
+Channel.prototype.subscribe = function(f, c) {
+    // need a function to call
+    forceFunction(f);
+    if (this.state == 2) {
+        f.apply(c || this, this.fireArgs);
+        return;
+    }
+
+    var func = f,
+        guid = f.observer_guid;
+    if (typeof c == "object") { func = utils.close(c, f); }
+
+    if (!guid) {
+        // first time any channel has seen this subscriber
+        guid = '' + nextGuid++;
+    }
+    func.observer_guid = guid;
+    f.observer_guid = guid;
+
+    // Don't add the same handler more than once.
+    if (!this.handlers[guid]) {
+        this.handlers[guid] = func;
+        this.numHandlers++;
+        if (this.numHandlers == 1) {
+            this.onHasSubscribersChange && this.onHasSubscribersChange();
+        }
+    }
+};
+
+/**
+ * Unsubscribes the function with the given guid from the channel.
+ */
+Channel.prototype.unsubscribe = function(f) {
+    // need a function to unsubscribe
+    forceFunction(f);
+
+    var guid = f.observer_guid,
+        handler = this.handlers[guid];
+    if (handler) {
+        delete this.handlers[guid];
+        this.numHandlers--;
+        if (this.numHandlers === 0) {
+            this.onHasSubscribersChange && this.onHasSubscribersChange();
+        }
+    }
+};
+
+/**
+ * Calls all functions subscribed to this channel.
+ */
+Channel.prototype.fire = function(e) {
+    var fail = false,
+        fireArgs = Array.prototype.slice.call(arguments);
+    // Apply stickiness.
+    if (this.state == 1) {
+        this.state = 2;
+        this.fireArgs = fireArgs;
+    }
+    if (this.numHandlers) {
+        // Copy the values first so that it is safe to modify it from within
+        // callbacks.
+        var toCall = [];
+        for (var item in this.handlers) {
+            toCall.push(this.handlers[item]);
+        }
+        for (var i = 0; i < toCall.length; ++i) {
+            toCall[i].apply(this, fireArgs);
+        }
+        if (this.state == 2 && this.numHandlers) {
+            this.numHandlers = 0;
+            this.handlers = {};
+            this.onHasSubscribersChange && this.onHasSubscribersChange();
+        }
+    }
+};
+
+
+// defining them here so they are ready super fast!
+// DOM event that is received when the web page is loaded and parsed.
+channel.createSticky('onDOMContentLoaded');
+
+// Event to indicate the Cordova native side is ready.
+channel.createSticky('onNativeReady');
+
+// Event to indicate that all Cordova JavaScript objects have been created
+// and it's time to run plugin constructors.
+channel.createSticky('onCordovaReady');
+
+// Event to indicate that all automatically loaded JS plugins are loaded and ready.
+// FIXME remove this
+channel.createSticky('onPluginsReady');
+
+// Event to indicate that Cordova is ready
+channel.createSticky('onDeviceReady');
+
+// Event to indicate a resume lifecycle event
+channel.create('onResume');
+
+// Event to indicate a pause lifecycle event
+channel.create('onPause');
+
+// Event to indicate a destroy lifecycle event
+channel.createSticky('onDestroy');
+
+// Channels that must fire before "deviceready" is fired.
+channel.waitForInitialization('onCordovaReady');
+channel.waitForInitialization('onDOMContentLoaded');
+
+module.exports = channel;
+
+});
+
+// file: src/firefoxos/exec.js
+define("cordova/exec", function(require, exports, module) {
+
+//var firefoxos = require('cordova/platform');
+var cordova = require('cordova');
+var execProxy = require('cordova/exec/proxy');
+
+module.exports = function(success, fail, service, action, args) {
+    var proxy = execProxy.get(service,action);
+    if(proxy) {
+        var callbackId = service + cordova.callbackId++;
+        //console.log("EXEC:" + service + " : " + action);
+        if (typeof success == "function" || typeof fail == "function") {
+            cordova.callbacks[callbackId] = {success:success, fail:fail};
+        }
+        try {
+            proxy(success, fail, args);
+        }
+        catch(e) {
+            console.log("Exception calling native with command :: " + service + " :: " + action  + " ::exception=" + e);
+        }
+    }
+    else {
+        fail && fail("Missing Command Error");
+    }
+};
+
+});
+
+// file: src/common/exec/proxy.js
+define("cordova/exec/proxy", function(require, exports, module) {
+
+
+// internal map of proxy function
+var CommandProxyMap = {};
+
+module.exports = {
+
+    // example: cordova.commandProxy.add("Accelerometer",{getCurrentAcceleration: function(successCallback, errorCallback, options) {...},...);
+    add:function(id,proxyObj) {
+        console.log("adding proxy for " + id);
+        CommandProxyMap[id] = proxyObj;
+        return proxyObj;
+    },
+
+    // cordova.commandProxy.remove("Accelerometer");
+    remove:function(id) {
+        var proxy = CommandProxyMap[id];
+        delete CommandProxyMap[id];
+        CommandProxyMap[id] = null;
+        return proxy;
+    },
+
+    get:function(service,action) {
+        return ( CommandProxyMap[service] ? CommandProxyMap[service][action] : null );
+    }
+};
+});
+
+// file: src/firefoxos/firefoxos/commandProxy.js
+define("cordova/firefoxos/commandProxy", function(require, exports, module) {
+
+console.log('WARNING: please require cordova/exec/proxy instead');
+module.exports = require('cordova/exec/proxy');
+
+});
+
+// file: src/firefoxos/init.js
+define("cordova/init", function(require, exports, module) {
+
+/*
+ * This file has been copied into the firefoxos platform and patched
+ * to fix a problem with replacing the navigator object. We will have
+ * to keep this file up-to-date with the common init.js.
+ */
+
+var channel = require('cordova/channel');
+var cordova = require('cordova');
+var modulemapper = require('cordova/modulemapper');
+var platform = require('cordova/platform');
+var pluginloader = require('cordova/pluginloader');
+
+var platformInitChannelsArray = [channel.onNativeReady, channel.onPluginsReady];
+
+function logUnfiredChannels(arr) {
+    for (var i = 0; i < arr.length; ++i) {
+        if (arr[i].state != 2) {
+            console.log('Channel not fired: ' + arr[i].type);
+        }
+    }
+}
+
+window.setTimeout(function() {
+    if (channel.onDeviceReady.state != 2) {
+        console.log('deviceready has not fired after 5 seconds.');
+        logUnfiredChannels(platformInitChannelsArray);
+        logUnfiredChannels(channel.deviceReadyChannelsArray);
+    }
+}, 5000);
+
+// Replace navigator before any modules are required(), to ensure it happens as soon as possible.
+// We replace it so that properties that can't be clobbered can instead be overridden.
+function replaceNavigator(origNavigator) {
+    var CordovaNavigator = function() {};
+    CordovaNavigator.prototype = origNavigator;
+    var newNavigator = new CordovaNavigator();
+    // This work-around really only applies to new APIs that are newer than Function.bind.
+    // Without it, APIs such as getGamepads() break.
+    if (CordovaNavigator.bind) {
+        for (var key in origNavigator) {
+            try {
+                if (typeof origNavigator[key] == 'function') {
+                    newNavigator[key] = origNavigator[key].bind(origNavigator);
+                }
+            } catch(e) {
+                // This try/catch was added for Firefox OS 1.0 and 1.1
+                // because it throws an security exception when trying
+                // to access a few properties of the navigator object.
+                // It has been fixed in 1.2.
+            }
+        }
+    }
+    return newNavigator;
+}
+if (window.navigator) {
+    window.navigator = replaceNavigator(window.navigator);
+}
+
+if (!window.console) {
+    window.console = {
+        log: function(){}
+    };
+}
+if (!window.console.warn) {
+    window.console.warn = function(msg) {
+        this.log("warn: " + msg);
+    };
+}
+
+// Register pause, resume and deviceready channels as events on document.
+channel.onPause = cordova.addDocumentEventHandler('pause');
+channel.onResume = cordova.addDocumentEventHandler('resume');
+channel.onDeviceReady = cordova.addStickyDocumentEventHandler('deviceready');
+
+// Listen for DOMContentLoaded and notify our channel subscribers.
+if (document.readyState == 'complete' || document.readyState == 'interactive') {
+    channel.onDOMContentLoaded.fire();
+} else {
+    document.addEventListener('DOMContentLoaded', function() {
+        channel.onDOMContentLoaded.fire();
+    }, false);
+}
+
+// _nativeReady is global variable that the native side can set
+// to signify that the native code is ready. It is a global since
+// it may be called before any cordova JS is ready.
+if (window._nativeReady) {
+    channel.onNativeReady.fire();
+}
+
+modulemapper.clobbers('cordova', 'cordova');
+modulemapper.clobbers('cordova/exec', 'cordova.exec');
+modulemapper.clobbers('cordova/exec', 'Cordova.exec');
+
+// Call the platform-specific initialization.
+platform.bootstrap && platform.bootstrap();
+
+pluginloader.load(function() {
+    channel.onPluginsReady.fire();
+});
+
+/**
+ * Create all cordova objects once native side is ready.
+ */
+channel.join(function() {
+    modulemapper.mapModules(window);
+
+    platform.initialize && platform.initialize();
+
+    // Fire event to notify that all objects are created
+    channel.onCordovaReady.fire();
+
+    // Fire onDeviceReady event once page has fully loaded, all
+    // constructors have run and cordova info has been received from native
+    // side.
+    channel.join(function() {
+        require('cordova').fireDocumentEvent('deviceready');
+    }, channel.deviceReadyChannelsArray);
+
+}, platformInitChannelsArray);
+
+
+});
+
+// file: src/common/init_b.js
+define("cordova/init_b", function(require, exports, module) {
+
+var channel = require('cordova/channel');
+var cordova = require('cordova');
+var platform = require('cordova/platform');
+
+var platformInitChannelsArray = [channel.onDOMContentLoaded, channel.onNativeReady];
+
+// setting exec
+cordova.exec = require('cordova/exec');
+
+function logUnfiredChannels(arr) {
+    for (var i = 0; i < arr.length; ++i) {
+        if (arr[i].state != 2) {
+            console.log('Channel not fired: ' + arr[i].type);
+        }
+    }
+}
+
+window.setTimeout(function() {
+    if (channel.onDeviceReady.state != 2) {
+        console.log('deviceready has not fired after 5 seconds.');
+        logUnfiredChannels(platformInitChannelsArray);
+        logUnfiredChannels(channel.deviceReadyChannelsArray);
+    }
+}, 5000);
+
+// Replace navigator before any modules are required(), to ensure it happens as soon as possible.
+// We replace it so that properties that can't be clobbered can instead be overridden.
+function replaceNavigator(origNavigator) {
+    var CordovaNavigator = function() {};
+    CordovaNavigator.prototype = origNavigator;
+    var newNavigator = new CordovaNavigator();
+    // This work-around really only applies to new APIs that are newer than Function.bind.
+    // Without it, APIs such as getGamepads() break.
+    if (CordovaNavigator.bind) {
+        for (var key in origNavigator) {
+            if (typeof origNavigator[key] == 'function') {
+                newNavigator[key] = origNavigator[key].bind(origNavigator);
+            }
+        }
+    }
+    return newNavigator;
+}
+if (window.navigator) {
+    window.navigator = replaceNavigator(window.navigator);
+}
+
+if (!window.console) {
+    window.console = {
+        log: function(){}
+    };
+}
+if (!window.console.warn) {
+    window.console.warn = function(msg) {
+        this.log("warn: " + msg);
+    };
+}
+
+// Register pause, resume and deviceready channels as events on document.
+channel.onPause = cordova.addDocumentEventHandler('pause');
+channel.onResume = cordova.addDocumentEventHandler('resume');
+channel.onDeviceReady = cordova.addStickyDocumentEventHandler('deviceready');
+
+// Listen for DOMContentLoaded and notify our channel subscribers.
+if (document.readyState == 'complete' || document.readyState == 'interactive') {
+    channel.onDOMContentLoaded.fire();
+} else {
+    document.addEventListener('DOMContentLoaded', function() {
+        channel.onDOMContentLoaded.fire();
+    }, false);
+}
+
+// _nativeReady is global variable that the native side can set
+// to signify that the native code is ready. It is a global since
+// it may be called before any cordova JS is ready.
+if (window._nativeReady) {
+    channel.onNativeReady.fire();
+}
+
+// Call the platform-specific initialization.
+platform.bootstrap && platform.bootstrap();
+
+/**
+ * Create all cordova objects once native side is ready.
+ */
+channel.join(function() {
+    
+    platform.initialize && platform.initialize();
+
+    // Fire event to notify that all objects are created
+    channel.onCordovaReady.fire();
+
+    // Fire onDeviceReady event once page has fully loaded, all
+    // constructors have run and cordova info has been received from native
+    // side.
+    channel.join(function() {
+        require('cordova').fireDocumentEvent('deviceready');
+    }, channel.deviceReadyChannelsArray);
+
+}, platformInitChannelsArray);
+
+});
+
+// file: src/common/modulemapper.js
+define("cordova/modulemapper", function(require, exports, module) {
+
+var builder = require('cordova/builder'),
+    moduleMap = define.moduleMap,
+    symbolList,
+    deprecationMap;
+
+exports.reset = function() {
+    symbolList = [];
+    deprecationMap = {};
+};
+
+function addEntry(strategy, moduleName, symbolPath, opt_deprecationMessage) {
+    if (!(moduleName in moduleMap)) {
+        throw new Error('Module ' + moduleName + ' does not exist.');
+    }
+    symbolList.push(strategy, moduleName, symbolPath);
+    if (opt_deprecationMessage) {
+        deprecationMap[symbolPath] = opt_deprecationMessage;
+    }
+}
+
+// Note: Android 2.3 does have Function.bind().
+exports.clobbers = function(moduleName, symbolPath, opt_deprecationMessage) {
+    addEntry('c', moduleName, symbolPath, opt_deprecationMessage);
+};
+
+exports.merges = function(moduleName, symbolPath, opt_deprecationMessage) {
+    addEntry('m', moduleName, symbolPath, opt_deprecationMessage);
+};
+
+exports.defaults = function(moduleName, symbolPath, opt_deprecationMessage) {
+    addEntry('d', moduleName, symbolPath, opt_deprecationMessage);
+};
+
+exports.runs = function(moduleName) {
+    addEntry('r', moduleName, null);
+};
+
+function prepareNamespace(symbolPath, context) {
+    if (!symbolPath) {
+        return context;
+    }
+    var parts = symbolPath.split('.');
+    var cur = context;
+    for (var i = 0, part; part = parts[i]; ++i) {
+        cur = cur[part] = cur[part] || {};
+    }
+    return cur;
+}
+
+exports.mapModules = function(context) {
+    var origSymbols = {};
+    context.CDV_origSymbols = origSymbols;
+    for (var i = 0, len = symbolList.length; i < len; i += 3) {
+        var strategy = symbolList[i];
+        var moduleName = symbolList[i + 1];
+        var module = require(moduleName);
+        // <runs/>
+        if (strategy == 'r') {
+            continue;
+        }
+        var symbolPath = symbolList[i + 2];
+        var lastDot = symbolPath.lastIndexOf('.');
+        var namespace = symbolPath.substr(0, lastDot);
+        var lastName = symbolPath.substr(lastDot + 1);
+
+        var deprecationMsg = symbolPath in deprecationMap ? 'Access made to deprecated symbol: ' + symbolPath + '. ' + deprecationMsg : null;
+        var parentObj = prepareNamespace(namespace, context);
+        var target = parentObj[lastName];
+
+        if (strategy == 'm' && target) {
+            builder.recursiveMerge(target, module);
+        } else if ((strategy == 'd' && !target) || (strategy != 'd')) {
+            if (!(symbolPath in origSymbols)) {
+                origSymbols[symbolPath] = target;
+            }
+            builder.assignOrWrapInDeprecateGetter(parentObj, lastName, module, deprecationMsg);
+        }
+    }
+};
+
+exports.getOriginalSymbol = function(context, symbolPath) {
+    var origSymbols = context.CDV_origSymbols;
+    if (origSymbols && (symbolPath in origSymbols)) {
+        return origSymbols[symbolPath];
+    }
+    var parts = symbolPath.split('.');
+    var obj = context;
+    for (var i = 0; i < parts.length; ++i) {
+        obj = obj && obj[parts[i]];
+    }
+    return obj;
+};
+
+exports.reset();
+
+
+});
+
+// file: src/firefoxos/platform.js
+define("cordova/platform", function(require, exports, module) {
+
+module.exports = {
+    id: 'firefoxos',
+
+    bootstrap: function() {
+        var modulemapper = require('cordova/modulemapper');
+
+        modulemapper.clobbers('cordova/exec/proxy', 'cordova.commandProxy');
+        require('cordova/channel').onNativeReady.fire();
+    }
+};
+
+});
+
+// file: src/common/pluginloader.js
+define("cordova/pluginloader", function(require, exports, module) {
+
+var modulemapper = require('cordova/modulemapper');
+var urlutil = require('cordova/urlutil');
+
+// Helper function to inject a <script> tag.
+// Exported for testing.
+exports.injectScript = function(url, onload, onerror) {
+    var script = document.createElement("script");
+    // onload fires even when script fails loads with an error.
+    script.onload = onload;
+    // onerror fires for malformed URLs.
+    script.onerror = onerror;
+    script.src = url;
+    document.head.appendChild(script);
+};
+
+function injectIfNecessary(id, url, onload, onerror) {
+    onerror = onerror || onload;
+    if (id in define.moduleMap) {
+        onload();
+    } else {
+        exports.injectScript(url, function() {
+            if (id in define.moduleMap) {
+                onload();
+            } else {
+                onerror();
+            }
+        }, onerror);
+    }
+}
+
+function onScriptLoadingComplete(moduleList, finishPluginLoading) {
+    // Loop through all the plugins and then through their clobbers and merges.
+    for (var i = 0, module; module = moduleList[i]; i++) {
+        if (module.clobbers && module.clobbers.length) {
+            for (var j = 0; j < module.clobbers.length; j++) {
+                modulemapper.clobbers(module.id, module.clobbers[j]);
+            }
+        }
+
+        if (module.merges && module.merges.length) {
+            for (var k = 0; k < module.merges.length; k++) {
+                modulemapper.merges(module.id, module.merges[k]);
+            }
+        }
+
+        // Finally, if runs is truthy we want to simply require() the module.
+        if (module.runs) {
+            modulemapper.runs(module.id);
+        }
+    }
+
+    finishPluginLoading();
+}
+
+// Handler for the cordova_plugins.js content.
+// See plugman's plugin_loader.js for the details of this object.
+// This function is only called if the really is a plugins array that isn't empty.
+// Otherwise the onerror response handler will just call finishPluginLoading().
+function handlePluginsObject(path, moduleList, finishPluginLoading) {
+    // Now inject the scripts.
+    var scriptCounter = moduleList.length;
+
+    if (!scriptCounter) {
+        finishPluginLoading();
+        return;
+    }
+    function scriptLoadedCallback() {
+        if (!--scriptCounter) {
+            onScriptLoadingComplete(moduleList, finishPluginLoading);
+        }
+    }
+
+    for (var i = 0; i < moduleList.length; i++) {
+        injectIfNecessary(moduleList[i].id, path + moduleList[i].file, scriptLoadedCallback);
+    }
+}
+
+function findCordovaPath() {
+    var path = null;
+    var scripts = document.getElementsByTagName('script');
+    var term = '/cordova.js';
+    for (var n = scripts.length-1; n>-1; n--) {
+        var src = scripts[n].src.replace(/\?.*$/, ''); // Strip any query param (CB-6007).
+        if (src.indexOf(term) == (src.length - term.length)) {
+            path = src.substring(0, src.length - term.length) + '/';
+            break;
+        }
+    }
+    return path;
+}
+
+// Tries to load all plugins' js-modules.
+// This is an async process, but onDeviceReady is blocked on onPluginsReady.
+// onPluginsReady is fired when there are no plugins to load, or they are all done.
+exports.load = function(callback) {
+    var pathPrefix = findCordovaPath();
+    if (pathPrefix === null) {
+        console.log('Could not find cordova.js script tag. Plugin loading may fail.');
+        pathPrefix = '';
+    }
+    injectIfNecessary('cordova/plugin_list', pathPrefix + 'cordova_plugins.js', function() {
+        var moduleList = require("cordova/plugin_list");
+        handlePluginsObject(pathPrefix, moduleList, callback);
+    }, callback);
+};
+
+
+});
+
+// file: src/common/urlutil.js
+define("cordova/urlutil", function(require, exports, module) {
+
+
+/**
+ * For already absolute URLs, returns what is passed in.
+ * For relative URLs, converts them to absolute ones.
+ */
+exports.makeAbsolute = function makeAbsolute(url) {
+    var anchorEl = document.createElement('a');
+    anchorEl.href = url;
+    return anchorEl.href;
+};
+
+
+});
+
+// file: src/common/utils.js
+define("cordova/utils", function(require, exports, module) {
+
+var utils = exports;
+
+/**
+ * Defines a property getter / setter for obj[key].
+ */
+utils.defineGetterSetter = function(obj, key, getFunc, opt_setFunc) {
+    if (Object.defineProperty) {
+        var desc = {
+            get: getFunc,
+            configurable: true
+        };
+        if (opt_setFunc) {
+            desc.set = opt_setFunc;
+        }
+        Object.defineProperty(obj, key, desc);
+    } else {
+        obj.__defineGetter__(key, getFunc);
+        if (opt_setFunc) {
+            obj.__defineSetter__(key, opt_setFunc);
+        }
+    }
+};
+
+/**
+ * Defines a property getter for obj[key].
+ */
+utils.defineGetter = utils.defineGetterSetter;
+
+utils.arrayIndexOf = function(a, item) {
+    if (a.indexOf) {
+        return a.indexOf(item);
+    }
+    var len = a.length;
+    for (var i = 0; i < len; ++i) {
+        if (a[i] == item) {
+            return i;
+        }
+    }
+    return -1;
+};
+
+/**
+ * Returns whether the item was found in the array.
+ */
+utils.arrayRemove = function(a, item) {
+    var index = utils.arrayIndexOf(a, item);
+    if (index != -1) {
+        a.splice(index, 1);
+    }
+    return index != -1;
+};
+
+utils.typeName = function(val) {
+    return Object.prototype.toString.call(val).slice(8, -1);
+};
+
+/**
+ * Returns an indication of whether the argument is an array or not
+ */
+utils.isArray = function(a) {
+    return utils.typeName(a) == 'Array';
+};
+
+/**
+ * Returns an indication of whether the argument is a Date or not
+ */
+utils.isDate = function(d) {
+    return utils.typeName(d) == 'Date';
+};
+
+/**
+ * Does a deep clone of the object.
+ */
+utils.clone = function(obj) {
+    if(!obj || typeof obj == 'function' || utils.isDate(obj) || typeof obj != 'object') {
+        return obj;
+    }
+
+    var retVal, i;
+
+    if(utils.isArray(obj)){
+        retVal = [];
+        for(i = 0; i < obj.length; ++i){
+            retVal.push(utils.clone(obj[i]));
+        }
+        return retVal;
+    }
+
+    retVal = {};
+    for(i in obj){
+        if(!(i in retVal) || retVal[i] != obj[i]) {
+            retVal[i] = utils.clone(obj[i]);
+        }
+    }
+    return retVal;
+};
+
+/**
+ * Returns a wrapped version of the function
+ */
+utils.close = function(context, func, params) {
+    if (typeof params == 'undefined') {
+        return function() {
+            return func.apply(context, arguments);
+        };
+    } else {
+        return function() {
+            return func.apply(context, params);
+        };
+    }
+};
+
+/**
+ * Create a UUID
+ */
+utils.createUUID = function() {
+    return UUIDcreatePart(4) + '-' +
+        UUIDcreatePart(2) + '-' +
+        UUIDcreatePart(2) + '-' +
+        UUIDcreatePart(2) + '-' +
+        UUIDcreatePart(6);
+};
+
+/**
+ * Extends a child object from a parent object using classical inheritance
+ * pattern.
+ */
+utils.extend = (function() {
+    // proxy used to establish prototype chain
+    var F = function() {};
+    // extend Child from Parent
+    return function(Child, Parent) {
+        F.prototype = Parent.prototype;
+        Child.prototype = new F();
+        Child.__super__ = Parent.prototype;
+        Child.prototype.constructor = Child;
+    };
+}());
+
+/**
+ * Alerts a message in any available way: alert or console.log.
+ */
+utils.alert = function(msg) {
+    if (window.alert) {
+        window.alert(msg);
+    } else if (console && console.log) {
+        console.log(msg);
+    }
+};
+
+
+//------------------------------------------------------------------------------
+function UUIDcreatePart(length) {
+    var uuidpart = "";
+    for (var i=0; i<length; i++) {
+        var uuidchar = parseInt((Math.random() * 256), 10).toString(16);
+        if (uuidchar.length == 1) {
+            uuidchar = "0" + uuidchar;
+        }
+        uuidpart += uuidchar;
+    }
+    return uuidpart;
+}
+
+
+});
+
+window.cordova = require('cordova');
+// file: src/scripts/bootstrap.js
+
+require('cordova/init');
+
+})();

--- a/res/middleware/cordova/3.6.3/firefoxos/cordova_plugins.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/cordova_plugins.js
@@ -1,0 +1,577 @@
+cordova.define('cordova/plugin_list', function(require, exports, module) {
+module.exports = [
+    {
+        "file": "plugins/ADBMobile/sdks/Cordova/ADBMobile/Shared/ADBHelper.js",
+        "id": "ADBMobile.ADBHelper",
+        "clobbers": [
+            "ADB"
+        ]
+    },
+    {
+        "file": "plugins/nl.x-services.plugins.insomnia/www/Insomnia.js",
+        "id": "nl.x-services.plugins.insomnia.Insomnia",
+        "clobbers": [
+            "window.plugins.insomnia"
+        ]
+    },
+    {
+        "file": "plugins/nl.x-services.plugins.insomnia/src/firefoxos/insomnia.js",
+        "id": "nl.x-services.plugins.insomnia.InsomniaProxy",
+        "runs": true
+    },
+    {
+        "file": "plugins/org.apache.cordova.battery-status/www/battery.js",
+        "id": "org.apache.cordova.battery-status.battery",
+        "clobbers": [
+            "navigator.battery"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.battery-status/src/firefoxos/BatteryProxy.js",
+        "id": "org.apache.cordova.battery-status.Battery",
+        "runs": true
+    },
+    {
+        "file": "plugins/org.apache.cordova.camera/www/CameraConstants.js",
+        "id": "org.apache.cordova.camera.Camera",
+        "clobbers": [
+            "Camera"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.camera/www/CameraPopoverOptions.js",
+        "id": "org.apache.cordova.camera.CameraPopoverOptions",
+        "clobbers": [
+            "CameraPopoverOptions"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.camera/www/Camera.js",
+        "id": "org.apache.cordova.camera.camera",
+        "clobbers": [
+            "navigator.camera"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.camera/src/firefoxos/CameraProxy.js",
+        "id": "org.apache.cordova.camera.CameraProxy",
+        "runs": true
+    },
+    {
+        "file": "plugins/org.apache.cordova.contacts/www/contacts.js",
+        "id": "org.apache.cordova.contacts.contacts",
+        "clobbers": [
+            "navigator.contacts"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.contacts/www/Contact.js",
+        "id": "org.apache.cordova.contacts.Contact",
+        "clobbers": [
+            "Contact"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.contacts/www/ContactAddress.js",
+        "id": "org.apache.cordova.contacts.ContactAddress",
+        "clobbers": [
+            "ContactAddress"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.contacts/www/ContactError.js",
+        "id": "org.apache.cordova.contacts.ContactError",
+        "clobbers": [
+            "ContactError"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.contacts/www/ContactField.js",
+        "id": "org.apache.cordova.contacts.ContactField",
+        "clobbers": [
+            "ContactField"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.contacts/www/ContactFindOptions.js",
+        "id": "org.apache.cordova.contacts.ContactFindOptions",
+        "clobbers": [
+            "ContactFindOptions"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.contacts/www/ContactName.js",
+        "id": "org.apache.cordova.contacts.ContactName",
+        "clobbers": [
+            "ContactName"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.contacts/www/ContactOrganization.js",
+        "id": "org.apache.cordova.contacts.ContactOrganization",
+        "clobbers": [
+            "ContactOrganization"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.contacts/www/ContactFieldType.js",
+        "id": "org.apache.cordova.contacts.ContactFieldType",
+        "merges": [
+            ""
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.contacts/src/firefoxos/ContactsProxy.js",
+        "id": "org.apache.cordova.contacts.ContactsProxy",
+        "runs": true
+    },
+    {
+        "file": "plugins/org.apache.cordova.device/www/device.js",
+        "id": "org.apache.cordova.device.device",
+        "clobbers": [
+            "device"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.device/src/firefoxos/DeviceProxy.js",
+        "id": "org.apache.cordova.device.DeviceProxy",
+        "runs": true
+    },
+    {
+        "file": "plugins/org.apache.cordova.device-motion/www/Acceleration.js",
+        "id": "org.apache.cordova.device-motion.Acceleration",
+        "clobbers": [
+            "Acceleration"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.device-motion/www/accelerometer.js",
+        "id": "org.apache.cordova.device-motion.accelerometer",
+        "clobbers": [
+            "navigator.accelerometer"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.device-motion/src/firefoxos/accelerometer.js",
+        "id": "org.apache.cordova.device-motion.accelerometer-impl",
+        "runs": true
+    },
+    {
+        "file": "plugins/org.apache.cordova.device-orientation/www/CompassError.js",
+        "id": "org.apache.cordova.device-orientation.CompassError",
+        "clobbers": [
+            "CompassError"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.device-orientation/www/CompassHeading.js",
+        "id": "org.apache.cordova.device-orientation.CompassHeading",
+        "clobbers": [
+            "CompassHeading"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.device-orientation/www/compass.js",
+        "id": "org.apache.cordova.device-orientation.compass",
+        "clobbers": [
+            "navigator.compass"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.device-orientation/src/firefoxos/compass.js",
+        "id": "org.apache.cordova.device-orientation.compass-impl",
+        "runs": true
+    },
+    {
+        "file": "plugins/org.apache.cordova.dialogs/www/notification.js",
+        "id": "org.apache.cordova.dialogs.notification",
+        "merges": [
+            "navigator.notification"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.dialogs/src/firefoxos/notification.js",
+        "id": "org.apache.cordova.dialogs.dialogs-impl",
+        "runs": true
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/DirectoryEntry.js",
+        "id": "org.apache.cordova.file.DirectoryEntry",
+        "clobbers": [
+            "window.DirectoryEntry"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/DirectoryReader.js",
+        "id": "org.apache.cordova.file.DirectoryReader",
+        "clobbers": [
+            "window.DirectoryReader"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/Entry.js",
+        "id": "org.apache.cordova.file.Entry",
+        "clobbers": [
+            "window.Entry"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/File.js",
+        "id": "org.apache.cordova.file.File",
+        "clobbers": [
+            "window.File"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/FileEntry.js",
+        "id": "org.apache.cordova.file.FileEntry",
+        "clobbers": [
+            "window.FileEntry"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/FileError.js",
+        "id": "org.apache.cordova.file.FileError",
+        "clobbers": [
+            "window.FileError"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/FileReader.js",
+        "id": "org.apache.cordova.file.FileReader",
+        "clobbers": [
+            "window.FileReader"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/FileSystem.js",
+        "id": "org.apache.cordova.file.FileSystem",
+        "clobbers": [
+            "window.FileSystem"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/FileUploadOptions.js",
+        "id": "org.apache.cordova.file.FileUploadOptions",
+        "clobbers": [
+            "window.FileUploadOptions"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/FileUploadResult.js",
+        "id": "org.apache.cordova.file.FileUploadResult",
+        "clobbers": [
+            "window.FileUploadResult"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/FileWriter.js",
+        "id": "org.apache.cordova.file.FileWriter",
+        "clobbers": [
+            "window.FileWriter"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/Flags.js",
+        "id": "org.apache.cordova.file.Flags",
+        "clobbers": [
+            "window.Flags"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/LocalFileSystem.js",
+        "id": "org.apache.cordova.file.LocalFileSystem",
+        "clobbers": [
+            "window.LocalFileSystem"
+        ],
+        "merges": [
+            "window"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/Metadata.js",
+        "id": "org.apache.cordova.file.Metadata",
+        "clobbers": [
+            "window.Metadata"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/ProgressEvent.js",
+        "id": "org.apache.cordova.file.ProgressEvent",
+        "clobbers": [
+            "window.ProgressEvent"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/fileSystems.js",
+        "id": "org.apache.cordova.file.fileSystems"
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/requestFileSystem.js",
+        "id": "org.apache.cordova.file.requestFileSystem",
+        "clobbers": [
+            "window.requestFileSystem"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/resolveLocalFileSystemURI.js",
+        "id": "org.apache.cordova.file.resolveLocalFileSystemURI",
+        "merges": [
+            "window"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/src/firefoxos/FileProxy.js",
+        "id": "org.apache.cordova.file.FileProxy",
+        "runs": true
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/fileSystemPaths.js",
+        "id": "org.apache.cordova.file.fileSystemPaths",
+        "merges": [
+            "cordova"
+        ],
+        "runs": true
+    },
+    {
+        "file": "plugins/org.apache.cordova.file/www/firefoxos/FileSystem.js",
+        "id": "org.apache.cordova.file.firefoxFileSystem",
+        "merges": [
+            "window.FileSystem"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file-transfer/www/FileTransferError.js",
+        "id": "org.apache.cordova.file-transfer.FileTransferError",
+        "clobbers": [
+            "window.FileTransferError"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file-transfer/www/FileTransfer.js",
+        "id": "org.apache.cordova.file-transfer.FileTransfer",
+        "clobbers": [
+            "window.FileTransfer"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.file-transfer/www/firefoxos/FileTransferProxy.js",
+        "id": "org.apache.cordova.file-transfer.FileTransferProxy",
+        "runs": true
+    },
+    {
+        "file": "plugins/org.apache.cordova.geolocation/src/firefoxos/GeolocationProxy.js",
+        "id": "org.apache.cordova.geolocation.GeolocationProxy",
+        "runs": true
+    },
+    {
+        "file": "plugins/org.apache.cordova.geolocation/www/Coordinates.js",
+        "id": "org.apache.cordova.geolocation.Coordinates",
+        "clobbers": [
+            "Coordinates"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.geolocation/www/PositionError.js",
+        "id": "org.apache.cordova.geolocation.PositionError",
+        "clobbers": [
+            "PositionError"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.geolocation/www/Position.js",
+        "id": "org.apache.cordova.geolocation.Position",
+        "clobbers": [
+            "Position"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.geolocation/www/geolocation.js",
+        "id": "org.apache.cordova.geolocation.geolocation",
+        "clobbers": [
+            "navigator.geolocation"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.globalization/www/GlobalizationError.js",
+        "id": "org.apache.cordova.globalization.GlobalizationError",
+        "clobbers": [
+            "window.GlobalizationError"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.globalization/www/globalization.js",
+        "id": "org.apache.cordova.globalization.globalization",
+        "clobbers": [
+            "navigator.globalization"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.globalization/src/firefoxos/GlobalizationProxy.js",
+        "id": "org.apache.cordova.globalization.GlobalizationProxy",
+        "runs": true
+    },
+    {
+        "file": "plugins/org.apache.cordova.inappbrowser/www/inappbrowser.js",
+        "id": "org.apache.cordova.inappbrowser.inappbrowser",
+        "clobbers": [
+            "window.open"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.inappbrowser/src/firefoxos/InAppBrowserProxy.js",
+        "id": "org.apache.cordova.inappbrowser.InAppBrowserProxy",
+        "merges": [
+            ""
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.media/www/MediaError.js",
+        "id": "org.apache.cordova.media.MediaError",
+        "clobbers": [
+            "window.MediaError"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.media/www/Media.js",
+        "id": "org.apache.cordova.media.Media",
+        "clobbers": [
+            "window.Media"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.media-capture/www/CaptureAudioOptions.js",
+        "id": "org.apache.cordova.media-capture.CaptureAudioOptions",
+        "clobbers": [
+            "CaptureAudioOptions"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.media-capture/www/CaptureImageOptions.js",
+        "id": "org.apache.cordova.media-capture.CaptureImageOptions",
+        "clobbers": [
+            "CaptureImageOptions"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.media-capture/www/CaptureVideoOptions.js",
+        "id": "org.apache.cordova.media-capture.CaptureVideoOptions",
+        "clobbers": [
+            "CaptureVideoOptions"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.media-capture/www/CaptureError.js",
+        "id": "org.apache.cordova.media-capture.CaptureError",
+        "clobbers": [
+            "CaptureError"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.media-capture/www/MediaFileData.js",
+        "id": "org.apache.cordova.media-capture.MediaFileData",
+        "clobbers": [
+            "MediaFileData"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.media-capture/www/MediaFile.js",
+        "id": "org.apache.cordova.media-capture.MediaFile",
+        "clobbers": [
+            "MediaFile"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.media-capture/www/capture.js",
+        "id": "org.apache.cordova.media-capture.capture",
+        "clobbers": [
+            "navigator.device.capture"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.network-information/www/network.js",
+        "id": "org.apache.cordova.network-information.network",
+        "clobbers": [
+            "navigator.connection",
+            "navigator.network.connection"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.network-information/www/Connection.js",
+        "id": "org.apache.cordova.network-information.Connection",
+        "clobbers": [
+            "Connection"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.network-information/src/firefoxos/NetworkProxy.js",
+        "id": "org.apache.cordova.network-information.NetworkProxy",
+        "runs": true
+    },
+    {
+        "file": "plugins/org.apache.cordova.splashscreen/www/splashscreen.js",
+        "id": "org.apache.cordova.splashscreen.SplashScreen",
+        "clobbers": [
+            "navigator.splashscreen"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.statusbar/www/statusbar.js",
+        "id": "org.apache.cordova.statusbar.statusbar",
+        "clobbers": [
+            "window.StatusBar"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.vibration/www/vibration.js",
+        "id": "org.apache.cordova.vibration.notification",
+        "merges": [
+            "navigator.notification",
+            "navigator"
+        ]
+    },
+    {
+        "file": "plugins/org.apache.cordova.vibration/src/firefoxos/VibrationProxy.js",
+        "id": "org.apache.cordova.vibration.VibrationProxy",
+        "runs": true
+    },
+    {
+        "file": "plugins/org.chromium.zip/zip.js",
+        "id": "org.chromium.zip.Zip",
+        "clobbers": [
+            "zip"
+        ]
+    },
+    {
+        "file": "plugins/org.chromium.zip/tests/tests.js",
+        "id": "org.chromium.zip.tests"
+    }
+];
+module.exports.metadata = 
+// TOP OF METADATA
+{
+    "ADBMobile": "1.0.0",
+    "nl.x-services.plugins.insomnia": "4.0.1",
+    "org.apache.cordova.battery-status": "0.2.11",
+    "org.apache.cordova.camera": "0.3.2",
+    "org.apache.cordova.console": "0.2.11",
+    "org.apache.cordova.contacts": "0.2.13",
+    "org.apache.cordova.device": "0.2.12",
+    "org.apache.cordova.device-motion": "0.2.10",
+    "org.apache.cordova.device-orientation": "0.3.9",
+    "org.apache.cordova.dialogs": "0.2.10",
+    "org.apache.cordova.file": "1.3.1",
+    "org.apache.cordova.file-transfer": "0.4.6",
+    "org.apache.cordova.geolocation": "0.3.10",
+    "org.apache.cordova.globalization": "0.3.1",
+    "org.apache.cordova.inappbrowser": "0.5.2",
+    "org.apache.cordova.media": "0.2.13",
+    "org.apache.cordova.media-capture": "0.3.3",
+    "org.apache.cordova.network-information": "0.2.12",
+    "org.apache.cordova.splashscreen": "0.3.3",
+    "org.apache.cordova.statusbar": "0.1.8",
+    "org.apache.cordova.vibration": "0.3.11",
+    "org.chromium.zip": "2.1.0"
+}
+// BOTTOM OF METADATA
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/ADBMobile/sdks/Cordova/ADBMobile/Shared/ADBHelper.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/ADBMobile/sdks/Cordova/ADBMobile/Shared/ADBHelper.js
@@ -1,0 +1,134 @@
+cordova.define("ADBMobile.ADBHelper", function(require, exports, module) { /*************************************************************************
+ *
+ * ADOBE CONFIDENTIAL
+ * ___________________
+ *
+ *  Copyright 2013 Adobe Systems Incorporated
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Adobe Systems Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Adobe Systems Incorporated and its
+ * suppliers and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe Systems Incorporated.
+ *
+ **************************************************************************/
+
+var ADB = (function () {
+	var ADB = (typeof exports !== 'undefined') && exports || {};
+	
+	ADB.doNothing = function () {};
+		
+	var PLUGIN_NAME = "ADBMobile_PhoneGap";
+	var fTRACK_APP_STATE_WITH_CDATA = "myMethod";
+	
+	ADB.optedIn = 1;
+	ADB.optedOut = 2;
+	ADB.optUnknown = 3;
+
+	ADB.trackAppState = function (stateName) {
+	   return cordova.exec(ADB.doNothing, ADB.doNothing, "ADBMobile_PhoneGap", "myMethod", [stateName]);
+	};
+	
+	ADB.getVersion = function(success, fail) {
+		return cordova.exec(success, fail, "ADBMobile_PhoneGap", "getVersion", [null]);
+	}
+	
+	ADB.getPrivacyStatus = function(success, fail) {
+		return cordova.exec(success, fail, "ADBMobile_PhoneGap", "getPrivacyStatus", [null]);
+	}
+	
+	ADB.setPrivacyStatus = function (privacyStatus) {
+		return cordova.exec(ADB.doNothing, ADB.doNothing, "ADBMobile_PhoneGap", "setPrivacyStatus", [privacyStatus]);
+	};
+	
+	ADB.getLifetimeValue = function(success, fail) {
+		return cordova.exec(success, fail, "ADBMobile_PhoneGap", "getLifetimeValue", [null]);
+	}
+
+	ADB.getUserIdentifier = function(success, fail) {
+		return cordova.exec(success, fail, "ADBMobile_PhoneGap", "getUserIdentifier", [null]);
+	}
+	
+	ADB.setUserIdentifier = function (userIdentifier) {
+		return cordova.exec(ADB.doNothing, ADB.doNothing, "ADBMobile_PhoneGap", "setUserIdentifier", [userIdentifier]);
+	};
+
+	ADB.getDebugLogging = function(success, fail) {
+		return cordova.exec(success, fail, "ADBMobile_PhoneGap", "getDebugLogging", [null]);
+	}
+
+	ADB.setDebugLogging = function(debugLogging) {
+		return cordova.exec(ADB.doNothing, ADB.doNothing, "ADBMobile_PhoneGap", "setDebugLogging", [debugLogging]);
+	}
+
+	ADB.keepLifecycleSessionAlive = function(success, fail) {
+		return cordova.exec(success, fail, "ADBMobile_PhoneGap", "keepLifecycleSessionAlive", [null]);
+	}
+
+	ADB.collectLifecycleData = function(success, fail) {
+		return cordova.exec(success, fail, "ADBMobile_PhoneGap", "collectLifecycleData", [null]);
+	}
+	
+	ADB.trackState = function(stateName, cData) {
+		return cordova.exec(ADB.doNothing, ADB.doNothing, "ADBMobile_PhoneGap", "trackState", [stateName, cData]);
+	}
+
+	ADB.trackAction = function(action, cData) {
+		return cordova.exec(ADB.doNothing, ADB.doNothing, "ADBMobile_PhoneGap", "trackAction", [action, cData]);
+	}
+	
+	ADB.trackActionFromBackground = function(action, cData) {
+		return cordova.exec(ADB.doNothing, ADB.doNothing, "ADBMobile_PhoneGap", "trackActionFromBackground", [action, cData]);
+	}
+
+	ADB.trackLocation = function(lat, long, cData) {
+		return cordova.exec(ADB.doNothing, ADB.doNothing, "ADBMobile_PhoneGap", "trackLocation", [lat, long, cData]);
+	}
+	
+	ADB.trackLifetimeValueIncrease = function(amount, cData) {
+		return cordova.exec(ADB.doNothing, ADB.doNothing, "ADBMobile_PhoneGap", "trackLifetimeValueIncrease", [amount, cData]);
+	}
+
+	ADB.trackTimedActionStart = function(action, cData) {
+		return cordova.exec(ADB.doNothing, ADB.doNothing, "ADBMobile_PhoneGap", "trackTimedActionStart", [action, cData]);
+	}
+
+	ADB.trackTimedActionUpdate = function(action, cData) {
+		return cordova.exec(ADB.doNothing, ADB.doNothing, "ADBMobile_PhoneGap", "trackTimedActionUpdate", [action, cData]);
+	}
+
+	ADB.trackTimedActionEnd = function(action) {
+		return cordova.exec(ADB.doNothing, ADB.doNothing, "ADBMobile_PhoneGap", "trackTimedActionEnd", [action]);
+	}
+
+	ADB.trackingTimedActionExists = function(success, fail, action) {
+		return cordova.exec(success, fail, "ADBMobile_PhoneGap", "trackingTimedActionExists", [action]);
+	}
+
+	ADB.trackingIdentifier = function(success, fail) {
+		return cordova.exec(success, fail, "ADBMobile_PhoneGap", "trackingIdentifier", []);
+	}
+
+	ADB.trackingClearQueue = function(success, fail) {
+		return cordova.exec(success, fail, "ADBMobile_PhoneGap", "trackingClearQueue", []);
+	}
+
+	ADB.trackingGetQueueSize = function(success, fail) {
+		return cordova.exec(success, fail, "ADBMobile_PhoneGap", "trackingGetQueueSize", []);
+	}
+		   
+	ADB.targetLoadRequest = function(success, fail, name, defaultContent, parameters) {
+	   return cordova.exec(success, fail, "ADBMobile_PhoneGap", "targetLoadRequest", [name, defaultContent, parameters]);
+	}
+
+   ADB.targetLoadOrderConfirmRequest = function(success, fail, name, orderId, orderTotal, productPurchaseId, parameters) {
+	   return cordova.exec(success, fail, "ADBMobile_PhoneGap", "targetLoadOrderConfirmRequest", [name, orderId, orderTotal, productPurchaseId, parameters]);
+   }
+
+	return ADB;
+}());
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/nl.x-services.plugins.insomnia/src/firefoxos/insomnia.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/nl.x-services.plugins.insomnia/src/firefoxos/insomnia.js
@@ -1,0 +1,18 @@
+cordova.define("nl.x-services.plugins.insomnia.InsomniaProxy", function(require, exports, module) { var lock;
+
+module.exports = {
+    keepAwake: function() {
+        if (navigator.requestWakeLock) {
+            lock = navigator.requestWakeLock("screen");
+        }
+    },
+    allowSleepAgain: function() {
+        if (lock && typeof lock.unlock === "function") {
+            lock.unlock();
+        }
+    }
+};
+
+require("cordova/exec/proxy").add("Insomnia", module.exports);
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/nl.x-services.plugins.insomnia/www/Insomnia.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/nl.x-services.plugins.insomnia/www/Insomnia.js
@@ -1,0 +1,22 @@
+cordova.define("nl.x-services.plugins.insomnia.Insomnia", function(require, exports, module) { function Insomnia() {
+}
+
+Insomnia.prototype.keepAwake = function (successCallback, errorCallback) {
+  cordova.exec(successCallback, errorCallback, "Insomnia", "keepAwake", []);
+};
+
+Insomnia.prototype.allowSleepAgain = function (successCallback, errorCallback) {
+  cordova.exec(successCallback, errorCallback, "Insomnia", "allowSleepAgain", []);
+};
+
+Insomnia.install = function () {
+  if (!window.plugins) {
+    window.plugins = {};
+  }
+
+  window.plugins.insomnia = new Insomnia();
+  return window.plugins.insomnia;
+};
+
+cordova.addConstructor(Insomnia.install);
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.battery-status/src/firefoxos/BatteryProxy.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.battery-status/src/firefoxos/BatteryProxy.js
@@ -1,0 +1,63 @@
+cordova.define("org.apache.cordova.battery-status.Battery", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+var mozBattery = cordova.require('cordova/modulemapper').getOriginalSymbol(window, 'navigator.battery') || navigator.mozBattery;
+
+var Battery = {
+    start: function(successCB, failCB, args, env) {
+        if (mozBattery) {
+            Battery.attachListeners(successCB);
+        } else {
+            failCB('Could not get window.navigator.battery');
+        }
+    },
+
+    stop: function() {
+        Battery.detachListeners();
+    },
+
+    attachListeners: function(_callBack) {
+
+        Battery.updateBatteryStatus(_callBack); // send a battery status event
+
+        mozBattery.addEventListener("chargingchange", function(){
+            _callBack({level: (mozBattery.level * 100), isPlugged: mozBattery.charging});
+        });
+
+        mozBattery.addEventListener("levelchange", function(){
+            _callBack({level: (mozBattery.level * 100), isPlugged: mozBattery.charging});
+        });
+    },
+
+    detachListeners: function() {
+
+        mozBattery.removeEventListener("chargingchange", null);
+        mozBattery.removeEventListener("levelchange", null);
+    },
+
+    updateBatteryStatus: function(_callBack) {
+        _callBack({level: (mozBattery.level * 100), isPlugged: mozBattery.charging});
+    }
+};
+
+require("cordova/exec/proxy").add("Battery", Battery);
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.battery-status/www/battery.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.battery-status/www/battery.js
@@ -1,0 +1,112 @@
+cordova.define("org.apache.cordova.battery-status.battery", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * This class contains information about the current battery status.
+ * @constructor
+ */
+var cordova = require('cordova'),
+    exec = require('cordova/exec');
+
+function handlers() {
+  return battery.channels.batterystatus.numHandlers +
+         battery.channels.batterylow.numHandlers +
+         battery.channels.batterycritical.numHandlers;
+}
+
+var STATUS_CRITICAL = 5;
+var STATUS_LOW = 20;
+
+var Battery = function() {
+    this._level = null;
+    this._isPlugged = null;
+    // Create new event handlers on the window (returns a channel instance)
+    this.channels = {
+      batterystatus:cordova.addWindowEventHandler("batterystatus"),
+      batterylow:cordova.addWindowEventHandler("batterylow"),
+      batterycritical:cordova.addWindowEventHandler("batterycritical")
+    };
+    for (var key in this.channels) {
+        this.channels[key].onHasSubscribersChange = Battery.onHasSubscribersChange;
+    }
+};
+/**
+ * Event handlers for when callbacks get registered for the battery.
+ * Keep track of how many handlers we have so we can start and stop the native battery listener
+ * appropriately (and hopefully save on battery life!).
+ */
+Battery.onHasSubscribersChange = function() {
+  // If we just registered the first handler, make sure native listener is started.
+  if (this.numHandlers === 1 && handlers() === 1) {
+      exec(battery._status, battery._error, "Battery", "start", []);
+  } else if (handlers() === 0) {
+      exec(null, null, "Battery", "stop", []);
+  }
+};
+
+/**
+ * Callback for battery status
+ *
+ * @param {Object} info            keys: level, isPlugged
+ */
+Battery.prototype._status = function (info) {
+
+    if (info) {
+        if (battery._level !== info.level || battery._isPlugged !== info.isPlugged) {
+            
+            if(info.level == null && battery._level != null) {
+                return; // special case where callback is called because we stopped listening to the native side.
+            }
+            
+            // Something changed. Fire batterystatus event
+            cordova.fireWindowEvent("batterystatus", info);
+
+            if (!info.isPlugged) { // do not fire low/critical if we are charging. issue: CB-4520
+                // note the following are NOT exact checks, as we want to catch a transition from 
+                // above the threshold to below. issue: CB-4519
+                if (battery._level > STATUS_CRITICAL && info.level <= STATUS_CRITICAL) { 
+                    // Fire critical battery event
+                    cordova.fireWindowEvent("batterycritical", info);
+                }
+                else if (battery._level > STATUS_LOW && info.level <= STATUS_LOW) {
+                    // Fire low battery event
+                    cordova.fireWindowEvent("batterylow", info);
+                }
+            }
+            battery._level = info.level;
+            battery._isPlugged = info.isPlugged;
+        }
+    }
+};
+
+/**
+ * Error callback for battery start
+ */
+Battery.prototype._error = function(e) {
+    console.log("Error initializing Battery: " + e);
+};
+
+var battery = new Battery();
+
+module.exports = battery;
+
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.camera/src/firefoxos/CameraProxy.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.camera/src/firefoxos/CameraProxy.js
@@ -1,0 +1,53 @@
+cordova.define("org.apache.cordova.camera.CameraProxy", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+function takePicture(success, error, opts) {
+    var pick = new MozActivity({
+        name: "pick",
+        data: {
+            type: ["image/*"]
+        }
+    });
+
+    pick.onerror = error || function() {};
+
+    pick.onsuccess = function() {
+        // image is returned as Blob in this.result.blob
+        // we need to call success with url or base64 encoded image
+        if (opts && opts.destinationType == 0) {
+            // TODO: base64
+            return;
+        }
+        if (!opts || !opts.destinationType || opts.destinationType > 0) {
+            // url
+            return success(window.URL.createObjectURL(this.result.blob));
+        }
+    };
+}
+
+module.exports = {
+    takePicture: takePicture,
+    cleanup: function(){}
+};
+
+require("cordova/exec/proxy").add("Camera", module.exports);
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.camera/www/Camera.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.camera/www/Camera.js
@@ -1,0 +1,77 @@
+cordova.define("org.apache.cordova.camera.camera", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    exec = require('cordova/exec'),
+    Camera = require('./Camera');
+    // XXX: commented out
+    //CameraPopoverHandle = require('./CameraPopoverHandle');
+
+var cameraExport = {};
+
+// Tack on the Camera Constants to the base camera plugin.
+for (var key in Camera) {
+    cameraExport[key] = Camera[key];
+}
+
+/**
+ * Gets a picture from source defined by "options.sourceType", and returns the
+ * image as defined by the "options.destinationType" option.
+
+ * The defaults are sourceType=CAMERA and destinationType=FILE_URI.
+ *
+ * @param {Function} successCallback
+ * @param {Function} errorCallback
+ * @param {Object} options
+ */
+cameraExport.getPicture = function(successCallback, errorCallback, options) {
+    argscheck.checkArgs('fFO', 'Camera.getPicture', arguments);
+    options = options || {};
+    var getValue = argscheck.getValue;
+
+    var quality = getValue(options.quality, 50);
+    var destinationType = getValue(options.destinationType, Camera.DestinationType.FILE_URI);
+    var sourceType = getValue(options.sourceType, Camera.PictureSourceType.CAMERA);
+    var targetWidth = getValue(options.targetWidth, -1);
+    var targetHeight = getValue(options.targetHeight, -1);
+    var encodingType = getValue(options.encodingType, Camera.EncodingType.JPEG);
+    var mediaType = getValue(options.mediaType, Camera.MediaType.PICTURE);
+    var allowEdit = !!options.allowEdit;
+    var correctOrientation = !!options.correctOrientation;
+    var saveToPhotoAlbum = !!options.saveToPhotoAlbum;
+    var popoverOptions = getValue(options.popoverOptions, null);
+    var cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
+
+    var args = [quality, destinationType, sourceType, targetWidth, targetHeight, encodingType,
+                mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection];
+
+    exec(successCallback, errorCallback, "Camera", "takePicture", args);
+    // XXX: commented out
+    //return new CameraPopoverHandle();
+};
+
+cameraExport.cleanup = function(successCallback, errorCallback) {
+    exec(successCallback, errorCallback, "Camera", "cleanup", []);
+};
+
+module.exports = cameraExport;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.camera/www/CameraConstants.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.camera/www/CameraConstants.js
@@ -1,0 +1,55 @@
+cordova.define("org.apache.cordova.camera.Camera", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+module.exports = {
+  DestinationType:{
+    DATA_URL: 0,         // Return base64 encoded string
+    FILE_URI: 1,         // Return file uri (content://media/external/images/media/2 for Android)
+    NATIVE_URI: 2        // Return native uri (eg. asset-library://... for iOS)
+  },
+  EncodingType:{
+    JPEG: 0,             // Return JPEG encoded image
+    PNG: 1               // Return PNG encoded image
+  },
+  MediaType:{
+    PICTURE: 0,          // allow selection of still pictures only. DEFAULT. Will return format specified via DestinationType
+    VIDEO: 1,            // allow selection of video only, ONLY RETURNS URL
+    ALLMEDIA : 2         // allow selection from all media types
+  },
+  PictureSourceType:{
+    PHOTOLIBRARY : 0,    // Choose image from picture library (same as SAVEDPHOTOALBUM for Android)
+    CAMERA : 1,          // Take picture from camera
+    SAVEDPHOTOALBUM : 2  // Choose image from picture library (same as PHOTOLIBRARY for Android)
+  },
+  PopoverArrowDirection:{
+      ARROW_UP : 1,        // matches iOS UIPopoverArrowDirection constants to specify arrow location on popover
+      ARROW_DOWN : 2,
+      ARROW_LEFT : 4,
+      ARROW_RIGHT : 8,
+      ARROW_ANY : 15
+  },
+  Direction:{
+      BACK: 0,
+      FRONT: 1
+  }
+};
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.camera/www/CameraPopoverOptions.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.camera/www/CameraPopoverOptions.js
@@ -1,0 +1,39 @@
+cordova.define("org.apache.cordova.camera.CameraPopoverOptions", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var Camera = require('./Camera');
+
+/**
+ * Encapsulates options for iOS Popover image picker
+ */
+var CameraPopoverOptions = function(x,y,width,height,arrowDir){
+    // information of rectangle that popover should be anchored to
+    this.x = x || 0;
+    this.y = y || 32;
+    this.width = width || 320;
+    this.height = height || 480;
+    // The direction of the popover arrow
+    this.arrowDir = arrowDir || Camera.PopoverArrowDirection.ARROW_ANY;
+};
+
+module.exports = CameraPopoverOptions;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/src/firefoxos/ContactsProxy.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/src/firefoxos/ContactsProxy.js
@@ -1,0 +1,465 @@
+cordova.define("org.apache.cordova.contacts.ContactsProxy", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/ 
+
+// Cordova contact definition: 
+// http://cordova.apache.org/docs/en/2.5.0/cordova_contacts_contacts.md.html#Contact
+// FxOS contact definition:
+// https://developer.mozilla.org/en-US/docs/Web/API/mozContact
+
+
+var Contact = require('./Contact');
+var ContactField = require('./ContactField');
+var ContactAddress = require('./ContactAddress');
+var ContactName = require('./ContactName');
+
+// XXX: a hack to check if id is "empty". Cordova inserts a
+// string "this string is supposed to be a unique identifier that will 
+// never show up on a device" if id is empty
+function _hasId(id) {
+    if (!id || id.indexOf(' ') >= 0) {
+        return false;
+    }
+    return true;
+}
+
+// Extend mozContact prototype to provide update from Cordova
+function updateFromCordova(contact, fromContact) {
+
+    function exportContactFieldArray(contactFieldArray, key) {
+        if (!key) {
+            key = 'value';
+        }                 
+        var arr = [];
+        for (var i=0; i < contactFieldArray.length; i++) {
+            arr.push(contactFieldArray[i][key]);
+        };                                       
+        return arr;
+    }              
+
+    function exportAddress(addresses) {
+        // TODO: check moz address format
+        var arr = [];
+        
+        for (var i=0; i < addresses.length; i++) {
+            var addr = {};
+            for (var key in addresses[i]) {
+                if (key == 'formatted' || key == 'id') {
+                    continue;
+                } else if (key == 'type') {
+                    addr[key] = [addresses[i][key]];
+                } else if (key == 'country') {
+                    addr['countryName'] = addresses[i][key];
+                } else {
+                    addr[key] = addresses[i][key];    
+                }
+            } 
+            arr.push(addr);
+        }                                 
+        return arr;
+    } 
+
+    function exportContactField(data) {
+        var contactFields = [];
+        for (var i=0; i < data.length; i++) {
+            var item = data[i];
+            if (item.value) {
+                var itemData = {value: item.value};
+                if (item.type) {
+                    itemData.type = [item.type];
+                }
+                if (item.pref) {
+                    itemData.pref = item.pref;
+                }
+                contactFields.push(itemData);
+            }
+        }
+        return contactFields;
+    }
+    // adding simple fields [contactField, eventualMozContactField]
+    var nameFields = [['givenName'], ['familyName'],  
+                      ['honorificPrefix'], ['honorificSuffix'],
+                      ['middleName', 'additionalName']];
+    var baseArrayFields = [['displayName', 'name'], ['nickname']];
+    var baseStringFields = [];
+    var j = 0; while(field = nameFields[j++]) {
+      if (fromContact.name[field[0]]) {
+        contact[field[1] || field[0]] = fromContact.name[field[0]].split(' ');
+      }
+    }
+    j = 0; while(field = baseArrayFields[j++]) {
+      if (fromContact[field[0]]) {
+        contact[field[1] || field[0]] = fromContact[field[0]].split(' ');
+      }
+    }
+    j = 0; while(field = baseStringFields[j++]) {
+      if (fromContact[field[0]]) {
+        contact[field[1] || field[0]] = fromContact[field[0]];
+      }
+    }
+    if (fromContact.birthday) {
+      contact.bday = new Date(fromContact.birthday);
+    }
+    if (fromContact.emails) {
+        var emails = exportContactField(fromContact.emails)
+        contact.email = emails;
+    }
+    if (fromContact.categories) {
+        contact.category = exportContactFieldArray(fromContact.categories);
+    }
+    if (fromContact.addresses) {
+        contact.adr = exportAddress(fromContact.addresses);
+    }
+    if (fromContact.phoneNumbers) {
+        contact.tel = exportContactField(fromContact.phoneNumbers);
+    }
+    if (fromContact.organizations) {
+        // XXX: organizations are saved in 2 arrays - org and jobTitle
+        //      depending on the usecase it might generate issues
+        //      where wrong title will be added to an organization
+        contact.org = exportContactFieldArray(fromContact.organizations, 'name');
+        contact.jobTitle = exportContactFieldArray(fromContact.organizations, 'title');
+    }
+    if (fromContact.note) {
+        contact.note = [fromContact.note];
+    }
+}
+
+
+// Extend Cordova Contact prototype to provide update from FFOS contact
+Contact.prototype.updateFromMozilla = function(moz) {
+    function exportContactField(data) {
+        var contactFields = [];
+        for (var i=0; i < data.length; i++) {
+            var item = data[i];
+            var itemData = new ContactField(item.type, item.value, item.pref);
+            contactFields.push(itemData);
+        }
+        return contactFields;
+    }
+
+    function makeContactFieldFromArray(data) {
+        var contactFields = [];
+        for (var i=0; i < data.length; i++) {
+            var itemData = new ContactField(null, data[i]);
+            contactFields.push(itemData);
+        }
+        return contactFields;
+    }
+
+    function exportAddresses(addresses) {
+        // TODO: check moz address format
+        var arr = [];
+        
+        for (var i=0; i < addresses.length; i++) {
+            var addr = {};
+            for (var key in addresses[i]) {
+                if (key == 'countryName') {
+                    addr['country'] = addresses[i][key];
+                } else if (key == 'type') {
+                    addr[key] = addresses[i][key].join(' ');
+                } else {
+                    addr[key] = addresses[i][key];    
+                }
+            } 
+            arr.push(addr);
+        }
+        return arr;
+    } 
+
+    function createOrganizations(orgs, jobs) {
+        orgs = (orgs) ? orgs : [];
+        jobs = (jobs) ? jobs : [];
+        var max_length = Math.max(orgs.length, jobs.length);
+        var organizations = [];
+        for (var i=0; i < max_length; i++) {
+            organizations.push(new ContactOrganization(
+                  null, null, orgs[i] || null, null, jobs[i] || null));
+        }
+        return organizations;
+    }
+
+    function createFormatted(name) {
+        var fields = ['honorificPrefix', 'givenName', 'middleName', 
+                      'familyName', 'honorificSuffix'];
+        var f = '';
+        for (var i = 0; i < fields.length; i++) {
+            if (name[fields[i]]) {
+                if (f) {
+                    f += ' ';
+                }
+                f += name[fields[i]];
+            }
+        }
+        return f;
+    }
+
+
+    if (moz.id) {
+        this.id = moz.id;
+    }
+    var nameFields = [['givenName'], ['familyName'], 
+                       ['honorificPrefix'], ['honorificSuffix'],
+                       ['additionalName', 'middleName']];
+    var baseArrayFields = [['name', 'displayName'], 'nickname', ['note']];
+    var baseStringFields = [];
+    var name = new ContactName();
+    var j = 0; while(field = nameFields[j++]) {
+        if (moz[field[0]]) {
+            name[field[1] || field[0]] = moz[field[0]].join(' ');
+        }
+    }
+    this.name = name;
+    j = 0; while(field = baseArrayFields[j++]) {
+        if (moz[field[0]]) {
+            this[field[1] || field[0]] = moz[field[0]].join(' ');
+        }
+    }
+    j = 0; while(field = baseStringFields[j++]) {
+        if (moz[field[0]]) {
+            this[field[1] || field[0]] = moz[field[0]];
+        }
+    }
+    // emails
+    if (moz.email) {
+        this.emails = exportContactField(moz.email);
+    }
+    // categories
+    if (moz.category) {
+        this.categories = makeContactFieldFromArray(moz.category);
+    }
+
+    // addresses
+    if (moz.adr) {
+        this.addresses = exportAddresses(moz.adr);
+    }
+
+    // phoneNumbers
+    if (moz.tel) {
+        this.phoneNumbers = exportContactField(moz.tel);
+    }
+    // birthday
+    if (moz.bday) {
+      this.birthday = Date.parse(moz.bday);
+    }
+    // organizations
+    if (moz.org || moz.jobTitle) {
+        // XXX: organizations array is created from org and jobTitle
+        this.organizations = createOrganizations(moz.org, moz.jobTitle);
+    }
+    // construct a read-only formatted value
+    this.name.formatted = createFormatted(this.name);
+
+    /*  Find out how to translate these parameters
+        // photo: Blob
+        // url: Array with metadata (?)
+        // impp: exportIM(contact.ims), TODO: find the moz impp definition
+        // anniversary
+        // sex
+        // genderIdentity
+        // key
+    */
+}
+
+
+function createMozillaFromCordova(successCB, errorCB, contact) {
+    var moz;
+    // get contact if exists
+    if (_hasId(contact.id)) {
+      var search = navigator.mozContacts.find({
+        filterBy: ['id'], filterValue: contact.id, filterOp: 'equals'});
+      search.onsuccess = function() {
+        moz = search.result[0];
+        updateFromCordova(moz, contact);
+        successCB(moz);
+      };
+      search.onerror = errorCB;
+      return;
+    }
+
+    // create empty contact
+    moz = new mozContact();
+    // if ('init' in moz) {
+      // 1.2 and below compatibility
+      // moz.init();
+    // }
+    updateFromCordova(moz, contact);
+    successCB(moz);
+}
+
+
+function createCordovaFromMozilla(moz) {
+    var contact = new Contact();
+    contact.updateFromMozilla(moz);
+    return contact;
+}
+
+
+// However API requires the ability to save multiple contacts, it is 
+// used to save only one element array
+function saveContacts(successCB, errorCB, contacts) {
+    // a closure which is holding the right moz contact
+    function makeSaveSuccessCB(moz) {
+        return function(result) {
+            // create contact from FXOS contact (might be different than
+            // the original one due to differences in API)
+            var contact = createCordovaFromMozilla(moz);
+            // call callback
+            successCB(contact);
+        }
+    }
+    var i=0;
+    var contact;
+    while(contact = contacts[i++]){
+        var moz = createMozillaFromCordova(function(moz) {
+          var request = navigator.mozContacts.save(moz);
+          // success and/or fail will be called every time a contact is saved
+          request.onsuccess = makeSaveSuccessCB(moz);
+          request.onerror = errorCB;                
+        }, function() {}, contact);
+    }
+}   
+
+
+// API provides a list of ids to be removed
+function remove(successCB, errorCB, ids) {
+    var i=0;
+    var id;
+    for (var i=0; i < ids.length; i++){
+        // throw an error if no id provided
+        if (!_hasId(ids[i])) {
+            console.error('FFOS: Attempt to remove unsaved contact');
+            errorCB(0);
+            return;
+        }
+        // check if provided id actually exists 
+        var search = navigator.mozContacts.find({
+            filterBy: ['id'], filterValue: ids[i], filterOp: 'equals'});
+        search.onsuccess = function() {
+            if (search.result.length === 0) {
+                console.error('FFOS: Attempt to remove a non existing contact');
+                errorCB(0);
+                return;
+            }
+            var moz = search.result[0];
+            var request = navigator.mozContacts.remove(moz);
+            request.onsuccess = successCB;
+            request.onerror = errorCB;
+        };
+        search.onerror = errorCB;
+    }
+}
+
+
+var mozContactSearchFields = [['name', 'displayName'], ['givenName'], 
+    ['familyName'], ['email'], ['tel'], ['jobTitle'], ['note'], 
+    ['tel', 'phoneNumbers'], ['email', 'emails']]; 
+// Searching by nickname and additionalName is forbidden in  1.3 and below
+// Searching by name is forbidden in 1.2 and below
+
+// finds if a key is allowed and returns FFOS name if different
+function getMozSearchField(key) {
+    if (mozContactSearchFields.indexOf([key]) >= 0) {
+        return key;
+    }
+    for (var i=0; i < mozContactSearchFields.length; i++) {
+        if (mozContactSearchFields[i].length > 1) {
+            if (mozContactSearchFields[i][1] === key) {
+                return mozContactSearchFields[i][0];
+            }
+        }
+    }
+    return false;
+}
+
+
+function _getAll(successCB, errorCB, params) {
+    // [contactField, eventualMozContactField]
+    var getall = navigator.mozContacts.getAll({});
+    var contacts = [];
+
+    getall.onsuccess = function() {
+        if (getall.result) {
+            contacts.push(createCordovaFromMozilla(getall.result));
+            getall.continue();
+        } else {
+            successCB(contacts);
+        }
+    };
+    getall.onerror = errorCB;
+}
+
+
+function search(successCB, errorCB, params) {
+    var options = params[1] || {}; 
+    if (!options.filter) {
+        return _getAll(successCB, errorCB, params);
+    }
+    var filterBy = [];
+    // filter and translate fields
+    for (var i=0; i < params[0].length; i++) {
+        var searchField = params[0][i];
+        var mozField = getMozSearchField(searchField);
+        if (searchField === 'name') {
+            // Cordova uses name for search by all name fields.
+            filterBy.push('givenName');
+            filterBy.push('familyName');
+            continue;
+        } 
+        if (searchField === 'displayName' && 'init' in new mozContact()) {
+            // ``init`` in ``mozContact`` indicates FFOS version 1.2 or below
+            // Searching by name (in moz) is then forbidden
+            console.log('FFOS ContactProxy: Unable to search by displayName on FFOS 1.2');
+            continue;
+        } 
+        if (mozField) {
+            filterBy.push(mozField);
+        } else {
+            console.log('FXOS ContactProxy: inallowed field passed to search filtered out: ' + searchField);
+        }
+    }
+
+    var mozOptions = {filterBy: filterBy, filterOp: 'startsWith'};
+    if (!options.multiple) {
+        mozOptions.filterLimit = 1;
+    }
+    mozOptions.filterValue = options.filter;
+    var request = navigator.mozContacts.find(mozOptions);
+    request.onsuccess = function() {
+        var contacts = [];
+        var mozContacts = request.result;
+        var moz = mozContacts[0];
+        for (var i=0; i < mozContacts.length; i++) {
+            contacts.push(createCordovaFromMozilla(mozContacts[i]));
+        }
+        successCB(contacts);
+    };
+    request.onerror = errorCB;
+}
+
+
+module.exports = {
+    save: saveContacts,
+    remove: remove,
+    search: search
+};    
+    
+require("cordova/exec/proxy").add("Contacts", module.exports);
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/Contact.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/Contact.js
@@ -1,0 +1,179 @@
+cordova.define("org.apache.cordova.contacts.Contact", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    exec = require('cordova/exec'),
+    ContactError = require('./ContactError'),
+    utils = require('cordova/utils');
+
+/**
+* Converts primitives into Complex Object
+* Currently only used for Date fields
+*/
+function convertIn(contact) {
+    var value = contact.birthday;
+    try {
+      contact.birthday = new Date(parseFloat(value));
+    } catch (exception){
+      console.log("Cordova Contact convertIn error: exception creating date.");
+    }
+    return contact;
+}
+
+/**
+* Converts Complex objects into primitives
+* Only conversion at present is for Dates.
+**/
+
+function convertOut(contact) {
+    var value = contact.birthday;
+    if (value !== null) {
+        // try to make it a Date object if it is not already
+        if (!utils.isDate(value)){
+            try {
+                value = new Date(value);
+            } catch(exception){
+                value = null;
+            }
+        }
+        if (utils.isDate(value)){
+            value = value.valueOf(); // convert to milliseconds
+        }
+        contact.birthday = value;
+    }
+    return contact;
+}
+
+/**
+* Contains information about a single contact.
+* @constructor
+* @param {DOMString} id unique identifier
+* @param {DOMString} displayName
+* @param {ContactName} name
+* @param {DOMString} nickname
+* @param {Array.<ContactField>} phoneNumbers array of phone numbers
+* @param {Array.<ContactField>} emails array of email addresses
+* @param {Array.<ContactAddress>} addresses array of addresses
+* @param {Array.<ContactField>} ims instant messaging user ids
+* @param {Array.<ContactOrganization>} organizations
+* @param {DOMString} birthday contact's birthday
+* @param {DOMString} note user notes about contact
+* @param {Array.<ContactField>} photos
+* @param {Array.<ContactField>} categories
+* @param {Array.<ContactField>} urls contact's web sites
+*/
+var Contact = function (id, displayName, name, nickname, phoneNumbers, emails, addresses,
+    ims, organizations, birthday, note, photos, categories, urls) {
+    this.id = id || null;
+    this.rawId = null;
+    this.displayName = displayName || null;
+    this.name = name || null; // ContactName
+    this.nickname = nickname || null;
+    this.phoneNumbers = phoneNumbers || null; // ContactField[]
+    this.emails = emails || null; // ContactField[]
+    this.addresses = addresses || null; // ContactAddress[]
+    this.ims = ims || null; // ContactField[]
+    this.organizations = organizations || null; // ContactOrganization[]
+    this.birthday = birthday || null;
+    this.note = note || null;
+    this.photos = photos || null; // ContactField[]
+    this.categories = categories || null; // ContactField[]
+    this.urls = urls || null; // ContactField[]
+};
+
+/**
+* Removes contact from device storage.
+* @param successCB success callback
+* @param errorCB error callback
+*/
+Contact.prototype.remove = function(successCB, errorCB) {
+    argscheck.checkArgs('FF', 'Contact.remove', arguments);
+    var fail = errorCB && function(code) {
+        errorCB(new ContactError(code));
+    };
+    if (this.id === null) {
+        fail(ContactError.UNKNOWN_ERROR);
+    }
+    else {
+        exec(successCB, fail, "Contacts", "remove", [this.id]);
+    }
+};
+
+/**
+* Creates a deep copy of this Contact.
+* With the contact ID set to null.
+* @return copy of this Contact
+*/
+Contact.prototype.clone = function() {
+    var clonedContact = utils.clone(this);
+    clonedContact.id = null;
+    clonedContact.rawId = null;
+
+    function nullIds(arr) {
+        if (arr) {
+            for (var i = 0; i < arr.length; ++i) {
+                arr[i].id = null;
+            }
+        }
+    }
+
+    // Loop through and clear out any id's in phones, emails, etc.
+    nullIds(clonedContact.phoneNumbers);
+    nullIds(clonedContact.emails);
+    nullIds(clonedContact.addresses);
+    nullIds(clonedContact.ims);
+    nullIds(clonedContact.organizations);
+    nullIds(clonedContact.categories);
+    nullIds(clonedContact.photos);
+    nullIds(clonedContact.urls);
+    return clonedContact;
+};
+
+/**
+* Persists contact to device storage.
+* @param successCB success callback
+* @param errorCB error callback
+*/
+Contact.prototype.save = function(successCB, errorCB) {
+    argscheck.checkArgs('FFO', 'Contact.save', arguments);
+    var fail = errorCB && function(code) {
+        errorCB(new ContactError(code));
+    };
+    var success = function(result) {
+        if (result) {
+            if (successCB) {
+                var fullContact = require('./contacts').create(result);
+                successCB(convertIn(fullContact));
+            }
+        }
+        else {
+            // no Entry object returned
+            fail(ContactError.UNKNOWN_ERROR);
+        }
+    };
+    var dupContact = convertOut(utils.clone(this));
+    exec(success, fail, "Contacts", "save", [dupContact]);
+};
+
+
+module.exports = Contact;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/ContactAddress.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/ContactAddress.js
@@ -1,0 +1,48 @@
+cordova.define("org.apache.cordova.contacts.ContactAddress", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+* Contact address.
+* @constructor
+* @param {DOMString} id unique identifier, should only be set by native code
+* @param formatted // NOTE: not a W3C standard
+* @param streetAddress
+* @param locality
+* @param region
+* @param postalCode
+* @param country
+*/
+
+var ContactAddress = function(pref, type, formatted, streetAddress, locality, region, postalCode, country) {
+    this.id = null;
+    this.pref = (typeof pref != 'undefined' ? pref : false);
+    this.type = type || null;
+    this.formatted = formatted || null;
+    this.streetAddress = streetAddress || null;
+    this.locality = locality || null;
+    this.region = region || null;
+    this.postalCode = postalCode || null;
+    this.country = country || null;
+};
+
+module.exports = ContactAddress;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/ContactError.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/ContactError.js
@@ -1,0 +1,44 @@
+cordova.define("org.apache.cordova.contacts.ContactError", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ *  ContactError.
+ *  An error code assigned by an implementation when an error has occurred
+ * @constructor
+ */
+var ContactError = function(err) {
+    this.code = (typeof err != 'undefined' ? err : null);
+};
+
+/**
+ * Error codes
+ */
+ContactError.UNKNOWN_ERROR = 0;
+ContactError.INVALID_ARGUMENT_ERROR = 1;
+ContactError.TIMEOUT_ERROR = 2;
+ContactError.PENDING_OPERATION_ERROR = 3;
+ContactError.IO_ERROR = 4;
+ContactError.NOT_SUPPORTED_ERROR = 5;
+ContactError.PERMISSION_DENIED_ERROR = 20;
+
+module.exports = ContactError;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/ContactField.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/ContactField.js
@@ -1,0 +1,39 @@
+cordova.define("org.apache.cordova.contacts.ContactField", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+* Generic contact field.
+* @constructor
+* @param {DOMString} id unique identifier, should only be set by native code // NOTE: not a W3C standard
+* @param type
+* @param value
+* @param pref
+*/
+var ContactField = function(type, value, pref) {
+    this.id = null;
+    this.type = (type && type.toString()) || null;
+    this.value = (value && value.toString()) || null;
+    this.pref = (typeof pref != 'undefined' ? pref : false);
+};
+
+module.exports = ContactField;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/ContactFieldType.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/ContactFieldType.js
@@ -1,0 +1,57 @@
+cordova.define("org.apache.cordova.contacts.ContactFieldType", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+    // Possible field names for various platforms.
+    // Some field names are platform specific
+
+    var fieldType = {
+        addresses:      "addresses",
+        birthday:       "birthday",
+        categories:     "categories",
+        country:        "country",
+        department:     "department",
+        displayName:    "displayName",
+        emails:         "emails",
+        familyName:     "familyName",
+        formatted:      "formatted",
+        givenName:      "givenName",
+        honorificPrefix: "honorificPrefix",
+        honorificSuffix: "honorificSuffix",
+        id:             "id",
+        ims:            "ims",
+        locality:       "locality",
+        middleName:     "middleName",
+        name:           "name",
+        nickname:       "nickname",
+        note:           "note",
+        organizations:  "organizations",
+        phoneNumbers:   "phoneNumbers",
+        photos:         "photos",
+        postalCode:     "postalCode",
+        region:         "region",
+        streetAddress:  "streetAddress",
+        title:          "title",
+        urls:           "urls"
+    };
+
+    module.exports = fieldType;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/ContactFindOptions.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/ContactFindOptions.js
@@ -1,0 +1,37 @@
+cordova.define("org.apache.cordova.contacts.ContactFindOptions", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * ContactFindOptions.
+ * @constructor
+ * @param filter used to match contacts against
+ * @param multiple boolean used to determine if more than one contact should be returned
+ */
+
+var ContactFindOptions = function(filter, multiple, desiredFields) {
+    this.filter = filter || '';
+    this.multiple = (typeof multiple != 'undefined' ? multiple : false);
+    this.desiredFields = typeof desiredFields != 'undefined' ? desiredFields : [];
+};
+
+module.exports = ContactFindOptions;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/ContactName.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/ContactName.js
@@ -1,0 +1,43 @@
+cordova.define("org.apache.cordova.contacts.ContactName", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+* Contact name.
+* @constructor
+* @param formatted // NOTE: not part of W3C standard
+* @param familyName
+* @param givenName
+* @param middle
+* @param prefix
+* @param suffix
+*/
+var ContactName = function(formatted, familyName, givenName, middle, prefix, suffix) {
+    this.formatted = formatted || null;
+    this.familyName = familyName || null;
+    this.givenName = givenName || null;
+    this.middleName = middle || null;
+    this.honorificPrefix = prefix || null;
+    this.honorificSuffix = suffix || null;
+};
+
+module.exports = ContactName;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/ContactOrganization.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/ContactOrganization.js
@@ -1,0 +1,46 @@
+cordova.define("org.apache.cordova.contacts.ContactOrganization", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+* Contact organization.
+* @constructor
+* @param {DOMString} id unique identifier, should only be set by native code // NOTE: not a W3C standard
+* @param name
+* @param dept
+* @param title
+* @param startDate
+* @param endDate
+* @param location
+* @param desc
+*/
+
+var ContactOrganization = function(pref, type, name, dept, title) {
+    this.id = null;
+    this.pref = (typeof pref != 'undefined' ? pref : false);
+    this.type = type || null;
+    this.name = name || null;
+    this.department = dept || null;
+    this.title = title || null;
+};
+
+module.exports = ContactOrganization;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/contacts.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.contacts/www/contacts.js
@@ -1,0 +1,100 @@
+cordova.define("org.apache.cordova.contacts.contacts", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    exec = require('cordova/exec'),
+    ContactError = require('./ContactError'),
+    utils = require('cordova/utils'),
+    Contact = require('./Contact'),
+    fieldType = require('./ContactFieldType');
+    
+
+/**
+* Represents a group of Contacts.
+* @constructor
+*/
+var contacts = {
+    fieldType: fieldType,
+    /**
+     * Returns an array of Contacts matching the search criteria.
+     * @param fields that should be searched
+     * @param successCB success callback
+     * @param errorCB error callback
+     * @param {ContactFindOptions} options that can be applied to contact searching
+     * @return array of Contacts matching search criteria
+     */
+    find:function(fields, successCB, errorCB, options) {
+        argscheck.checkArgs('afFO', 'contacts.find', arguments);
+        if (!fields.length) {
+            errorCB && errorCB(new ContactError(ContactError.INVALID_ARGUMENT_ERROR));
+        } else {
+            // missing 'options' param means return all contacts
+            options = options || {filter: '', multiple: true}
+            var win = function(result) {
+                var cs = [];
+                for (var i = 0, l = result.length; i < l; i++) {
+                    cs.push(contacts.create(result[i]));
+                }
+                successCB(cs);
+            };
+            exec(win, errorCB, "Contacts", "search", [fields, options]);
+        }
+    },
+    
+    /**
+     * This function picks contact from phone using contact picker UI
+     * @returns new Contact object
+     */
+    pickContact: function (successCB, errorCB) {
+
+        argscheck.checkArgs('fF', 'contacts.pick', arguments);
+
+        var win = function (result) {
+            // if Contacts.pickContact return instance of Contact object
+            // don't create new Contact object, use current
+            var contact = result instanceof Contact ? result : contacts.create(result);
+            successCB(contact);
+        };
+        exec(win, errorCB, "Contacts", "pickContact", []);
+    },
+
+    /**
+     * This function creates a new contact, but it does not persist the contact
+     * to device storage. To persist the contact to device storage, invoke
+     * contact.save().
+     * @param properties an object whose properties will be examined to create a new Contact
+     * @returns new Contact object
+     */
+    create:function(properties) {
+        argscheck.checkArgs('O', 'contacts.create', arguments);
+        var contact = new Contact();
+        for (var i in properties) {
+            if (typeof contact[i] !== 'undefined' && properties.hasOwnProperty(i)) {
+                contact[i] = properties[i];
+            }
+        }
+        return contact;
+    }
+};
+
+module.exports = contacts;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device-motion/src/firefoxos/accelerometer.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device-motion/src/firefoxos/accelerometer.js
@@ -1,0 +1,43 @@
+cordova.define("org.apache.cordova.device-motion.accelerometer-impl", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+function listener(success, ev) {
+    var acc = ev.accelerationIncludingGravity;
+    acc.timestamp = new Date().getTime();
+    success(acc);
+}
+
+var Accelerometer = {
+    start: function start(success, error) {
+        return window.addEventListener('devicemotion', function(ev) {
+            listener(success, ev);
+        }, false);
+    },
+
+    stop: function stop() {
+        window.removeEventListener('devicemotion', listener, false);
+    }
+};
+
+module.exports = Accelerometer;
+require('cordova/exec/proxy').add('Accelerometer', Accelerometer);
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device-motion/www/Acceleration.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device-motion/www/Acceleration.js
@@ -1,0 +1,31 @@
+cordova.define("org.apache.cordova.device-motion.Acceleration", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var Acceleration = function(x, y, z, timestamp) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+    this.timestamp = timestamp || (new Date()).getTime();
+};
+
+module.exports = Acceleration;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device-motion/www/accelerometer.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device-motion/www/accelerometer.js
@@ -1,0 +1,171 @@
+cordova.define("org.apache.cordova.device-motion.accelerometer", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * This class provides access to device accelerometer data.
+ * @constructor
+ */
+var argscheck = require('cordova/argscheck'),
+    utils = require("cordova/utils"),
+    exec = require("cordova/exec"),
+    Acceleration = require('./Acceleration');
+
+// Is the accel sensor running?
+var running = false;
+
+// Keeps reference to watchAcceleration calls.
+var timers = {};
+
+// Array of listeners; used to keep track of when we should call start and stop.
+var listeners = [];
+
+// Last returned acceleration object from native
+var accel = null;
+
+// Tells native to start.
+function start() {
+    exec(function(a) {
+        var tempListeners = listeners.slice(0);
+        accel = new Acceleration(a.x, a.y, a.z, a.timestamp);
+        for (var i = 0, l = tempListeners.length; i < l; i++) {
+            tempListeners[i].win(accel);
+        }
+    }, function(e) {
+        var tempListeners = listeners.slice(0);
+        for (var i = 0, l = tempListeners.length; i < l; i++) {
+            tempListeners[i].fail(e);
+        }
+    }, "Accelerometer", "start", []);
+    running = true;
+}
+
+// Tells native to stop.
+function stop() {
+    exec(null, null, "Accelerometer", "stop", []);
+    running = false;
+}
+
+// Adds a callback pair to the listeners array
+function createCallbackPair(win, fail) {
+    return {win:win, fail:fail};
+}
+
+// Removes a win/fail listener pair from the listeners array
+function removeListeners(l) {
+    var idx = listeners.indexOf(l);
+    if (idx > -1) {
+        listeners.splice(idx, 1);
+        if (listeners.length === 0) {
+            stop();
+        }
+    }
+}
+
+var accelerometer = {
+    /**
+     * Asynchronously acquires the current acceleration.
+     *
+     * @param {Function} successCallback    The function to call when the acceleration data is available
+     * @param {Function} errorCallback      The function to call when there is an error getting the acceleration data. (OPTIONAL)
+     * @param {AccelerationOptions} options The options for getting the accelerometer data such as timeout. (OPTIONAL)
+     */
+    getCurrentAcceleration: function(successCallback, errorCallback, options) {
+        argscheck.checkArgs('fFO', 'accelerometer.getCurrentAcceleration', arguments);
+
+        var p;
+        var win = function(a) {
+            removeListeners(p);
+            successCallback(a);
+        };
+        var fail = function(e) {
+            removeListeners(p);
+            errorCallback && errorCallback(e);
+        };
+
+        p = createCallbackPair(win, fail);
+        listeners.push(p);
+
+        if (!running) {
+            start();
+        }
+    },
+
+    /**
+     * Asynchronously acquires the acceleration repeatedly at a given interval.
+     *
+     * @param {Function} successCallback    The function to call each time the acceleration data is available
+     * @param {Function} errorCallback      The function to call when there is an error getting the acceleration data. (OPTIONAL)
+     * @param {AccelerationOptions} options The options for getting the accelerometer data such as timeout. (OPTIONAL)
+     * @return String                       The watch id that must be passed to #clearWatch to stop watching.
+     */
+    watchAcceleration: function(successCallback, errorCallback, options) {
+        argscheck.checkArgs('fFO', 'accelerometer.watchAcceleration', arguments);
+        // Default interval (10 sec)
+        var frequency = (options && options.frequency && typeof options.frequency == 'number') ? options.frequency : 10000;
+
+        // Keep reference to watch id, and report accel readings as often as defined in frequency
+        var id = utils.createUUID();
+
+        var p = createCallbackPair(function(){}, function(e) {
+            removeListeners(p);
+            errorCallback && errorCallback(e);
+        });
+        listeners.push(p);
+
+        timers[id] = {
+            timer:window.setInterval(function() {
+                if (accel) {
+                    successCallback(accel);
+                }
+            }, frequency),
+            listeners:p
+        };
+
+        if (running) {
+            // If we're already running then immediately invoke the success callback
+            // but only if we have retrieved a value, sample code does not check for null ...
+            if (accel) {
+                successCallback(accel);
+            }
+        } else {
+            start();
+        }
+
+        return id;
+    },
+
+    /**
+     * Clears the specified accelerometer watch.
+     *
+     * @param {String} id       The id of the watch returned from #watchAcceleration.
+     */
+    clearWatch: function(id) {
+        // Stop javascript timer & remove from timer list
+        if (id && timers[id]) {
+            window.clearInterval(timers[id].timer);
+            removeListeners(timers[id].listeners);
+            delete timers[id];
+        }
+    }
+};
+module.exports = accelerometer;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device-orientation/src/firefoxos/compass.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device-orientation/src/firefoxos/compass.js
@@ -1,0 +1,45 @@
+cordova.define("org.apache.cordova.device-orientation.compass-impl", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var Compass = {
+    getHeading: function(success, error) {
+        var listener = function(ev) {
+            var orient = {
+                trueHeading: ev.alpha,
+                magneticHeading: ev.alpha,
+                headingAccuracy: 0,
+                timestamp: new Date().getTime()
+            }
+            success(orient);
+            // remove listener after first response
+            window.removeEventListener('deviceorientation', listener, false);
+        }
+        return window.addEventListener('deviceorientation', listener, false);
+    },
+};
+
+var firefoxos = require('cordova/platform');
+
+module.exports = Compass;
+require('cordova/exec/proxy').add('Compass', Compass);
+
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device-orientation/www/CompassError.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device-orientation/www/CompassError.js
@@ -1,0 +1,36 @@
+cordova.define("org.apache.cordova.device-orientation.CompassError", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ *  CompassError.
+ *  An error code assigned by an implementation when an error has occurred
+ * @constructor
+ */
+var CompassError = function(err) {
+    this.code = (err !== undefined ? err : null);
+};
+
+CompassError.COMPASS_INTERNAL_ERR = 0;
+CompassError.COMPASS_NOT_SUPPORTED = 20;
+
+module.exports = CompassError;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device-orientation/www/CompassHeading.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device-orientation/www/CompassHeading.js
@@ -1,0 +1,31 @@
+cordova.define("org.apache.cordova.device-orientation.CompassHeading", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var CompassHeading = function(magneticHeading, trueHeading, headingAccuracy, timestamp) {
+  this.magneticHeading = magneticHeading;
+  this.trueHeading = trueHeading;
+  this.headingAccuracy = headingAccuracy;
+  this.timestamp = timestamp || new Date().getTime();
+};
+
+module.exports = CompassHeading;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device-orientation/www/compass.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device-orientation/www/compass.js
@@ -1,0 +1,105 @@
+cordova.define("org.apache.cordova.device-orientation.compass", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    exec = require('cordova/exec'),
+    utils = require('cordova/utils'),
+    CompassHeading = require('./CompassHeading'),
+    CompassError = require('./CompassError'),
+
+    timers = {},
+    compass = {
+        /**
+         * Asynchronously acquires the current heading.
+         * @param {Function} successCallback The function to call when the heading
+         * data is available
+         * @param {Function} errorCallback The function to call when there is an error
+         * getting the heading data.
+         * @param {CompassOptions} options The options for getting the heading data (not used).
+         */
+        getCurrentHeading:function(successCallback, errorCallback, options) {
+            argscheck.checkArgs('fFO', 'compass.getCurrentHeading', arguments);
+
+            var win = function(result) {
+                var ch = new CompassHeading(result.magneticHeading, result.trueHeading, result.headingAccuracy, result.timestamp);
+                successCallback(ch);
+            };
+            var fail = errorCallback && function(code) {
+                var ce = new CompassError(code);
+                errorCallback(ce);
+            };
+
+            // Get heading
+            exec(win, fail, "Compass", "getHeading", [options]);
+        },
+
+        /**
+         * Asynchronously acquires the heading repeatedly at a given interval.
+         * @param {Function} successCallback The function to call each time the heading
+         * data is available
+         * @param {Function} errorCallback The function to call when there is an error
+         * getting the heading data.
+         * @param {HeadingOptions} options The options for getting the heading data
+         * such as timeout and the frequency of the watch. For iOS, filter parameter
+         * specifies to watch via a distance filter rather than time.
+         */
+        watchHeading:function(successCallback, errorCallback, options) {
+            argscheck.checkArgs('fFO', 'compass.watchHeading', arguments);
+            // Default interval (100 msec)
+            var frequency = (options !== undefined && options.frequency !== undefined) ? options.frequency : 100;
+            var filter = (options !== undefined && options.filter !== undefined) ? options.filter : 0;
+
+            var id = utils.createUUID();
+            if (filter > 0) {
+                // is an iOS request for watch by filter, no timer needed
+                timers[id] = "iOS";
+                compass.getCurrentHeading(successCallback, errorCallback, options);
+            } else {
+                // Start watch timer to get headings
+                timers[id] = window.setInterval(function() {
+                    compass.getCurrentHeading(successCallback, errorCallback);
+                }, frequency);
+            }
+
+            return id;
+        },
+
+        /**
+         * Clears the specified heading watch.
+         * @param {String} watchId The ID of the watch returned from #watchHeading.
+         */
+        clearWatch:function(id) {
+            // Stop javascript timer & remove from timer list
+            if (id && timers[id]) {
+                if (timers[id] != "iOS") {
+                    clearInterval(timers[id]);
+                } else {
+                    // is iOS watch by filter so call into device to stop
+                    exec(null, null, "Compass", "stopHeading", []);
+                }
+                delete timers[id];
+            }
+        }
+    };
+
+module.exports = compass;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device/src/firefoxos/DeviceProxy.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device/src/firefoxos/DeviceProxy.js
@@ -1,0 +1,81 @@
+cordova.define("org.apache.cordova.device.DeviceProxy", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+//example UA String for Firefox OS 
+//Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0
+var firefoxos = require('cordova/platform');
+var cordova = require('cordova');
+
+//UA parsing not recommended but currently this is the only way to get the Firefox OS version
+//https://developer.mozilla.org/en-US/docs/Gecko_user_agent_string_reference
+
+//Should be replaced when better conversion to Firefox OS Version is available
+function convertVersionNumber(ver) {
+    var hashVersion = {
+        '18.0': '1.0.1',
+        '18.1': '1.1',
+        '26.0': '1.2',
+        '28.0': '1.3',
+        '30.0': '1.4',
+        '32.0': '2.0'
+    };
+    var rver = ver;
+    var sStr = ver.substring(0, 4);
+    if (hashVersion[sStr]) {
+        rver = hashVersion[sStr];
+    }
+    return (rver);
+
+}
+function getVersion() {
+    if (navigator.userAgent.match(/(mobile|tablet)/i)) {
+        var ffVersionArray = (navigator.userAgent.match(/Firefox\/([\d]+\.[\w]?\.?[\w]+)/));
+        if (ffVersionArray.length === 2) {
+            return (convertVersionNumber(ffVersionArray[1]));
+        }
+    }
+    return (null);
+}
+
+function getModel() {
+    var uaArray = navigator.userAgent.split(/\s*[;)(]\s*/);
+    if (navigator.userAgent.match(/(mobile|tablet)/i)) {
+        if (uaArray.length === 5) {
+            return (uaArray[2]);
+        }
+    }
+    return (null);
+}
+module.exports = {
+    getDeviceInfo: function (success, error) {
+        setTimeout(function () {
+            success({
+                platform: 'firefoxos',
+                model: getModel(),
+                version: getVersion(),
+                uuid: null
+            });
+        }, 0);
+    }
+};
+
+require("cordova/exec/proxy").add("Device", module.exports);
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device/www/device.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.device/www/device.js
@@ -1,0 +1,79 @@
+cordova.define("org.apache.cordova.device.device", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    channel = require('cordova/channel'),
+    utils = require('cordova/utils'),
+    exec = require('cordova/exec'),
+    cordova = require('cordova');
+
+channel.createSticky('onCordovaInfoReady');
+// Tell cordova channel to wait on the CordovaInfoReady event
+channel.waitForInitialization('onCordovaInfoReady');
+
+/**
+ * This represents the mobile device, and provides properties for inspecting the model, version, UUID of the
+ * phone, etc.
+ * @constructor
+ */
+function Device() {
+    this.available = false;
+    this.platform = null;
+    this.version = null;
+    this.uuid = null;
+    this.cordova = null;
+    this.model = null;
+
+    var me = this;
+
+    channel.onCordovaReady.subscribe(function() {
+        me.getInfo(function(info) {
+            //ignoring info.cordova returning from native, we should use value from cordova.version defined in cordova.js
+            //TODO: CB-5105 native implementations should not return info.cordova
+            var buildLabel = cordova.version;
+            me.available = true;
+            me.platform = info.platform;
+            me.version = info.version;
+            me.uuid = info.uuid;
+            me.cordova = buildLabel;
+            me.model = info.model;
+            channel.onCordovaInfoReady.fire();
+        },function(e) {
+            me.available = false;
+            utils.alert("[ERROR] Error initializing Cordova: " + e);
+        });
+    });
+}
+
+/**
+ * Get device info
+ *
+ * @param {Function} successCallback The function to call when the heading data is available
+ * @param {Function} errorCallback The function to call when there is an error getting the heading data. (OPTIONAL)
+ */
+Device.prototype.getInfo = function(successCallback, errorCallback) {
+    argscheck.checkArgs('fF', 'Device.getInfo', arguments);
+    exec(successCallback, errorCallback, "Device", "getDeviceInfo", []);
+};
+
+module.exports = new Device();
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.dialogs/src/firefoxos/notification.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.dialogs/src/firefoxos/notification.js
@@ -1,0 +1,156 @@
+cordova.define("org.apache.cordova.dialogs.dialogs-impl", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var modulemapper = require('cordova/modulemapper');
+
+
+var origOpenFunc = modulemapper.getOriginalSymbol(window, 'window.open');
+
+
+function _empty() {}
+
+
+function modal(message, callback, title, buttonLabels, domObjects) {
+    var mainWindow = window;
+    var modalWindow = origOpenFunc();
+    var modalDocument = modalWindow.document;
+
+    modalDocument.write(
+        '<html><head>' +
+        '<link rel="stylesheet" type="text/css" href="/css/index.css" />' +
+        '<link rel="stylesheet" type="text/css" href="/css/notification.css" />' +
+        '</head><body></body></html>');
+
+    var box = modalDocument.createElement('form');
+    box.setAttribute('role', 'dialog');
+    // prepare and append empty section
+    var section = modalDocument.createElement('section');
+    box.appendChild(section);
+    // add title
+    var boxtitle = modalDocument.createElement('h1');
+    boxtitle.appendChild(modalDocument.createTextNode(title));
+    section.appendChild(boxtitle);
+    // add message
+    var boxMessage = modalDocument.createElement('p');
+    boxMessage.appendChild(modalDocument.createTextNode(message));
+    section.appendChild(boxMessage);
+    // inject what's needed
+    if (domObjects) {
+        section.appendChild(domObjects);
+    }
+    // add buttons and assign callbackButton on click
+    var menu = modalDocument.createElement('menu');
+    box.appendChild(menu);
+    for (var index = 0; index < buttonLabels.length; index++) {
+        addButton(buttonLabels[index], index, (index === 0));
+    }
+    modalDocument.body.appendChild(box);
+
+    function addButton(label, index, recommended) {
+        var thisButtonCallback = makeCallbackButton(index + 1);
+        var button = modalDocument.createElement('button');
+        button.appendChild(modalDocument.createTextNode(label));
+        button.addEventListener('click', thisButtonCallback, false);
+        if (recommended) {
+          // TODO: default one listens to Enter key
+          button.classList.add('recommend');
+        }
+        menu.appendChild(button);
+    }
+
+    // TODO: onUnload listens to the cancel key
+    function onUnload() {
+        var result = 0;
+        if (modalDocument.getElementById('prompt-input')) {
+            result = {
+                input1: '',
+                buttonIndex: 0
+            }
+        }
+        mainWindow.setTimeout(function() {
+            callback(result);
+        }, 10);
+    };
+    modalWindow.addEventListener('unload', onUnload, false);
+
+    // call callback and destroy modal
+    function makeCallbackButton(labelIndex) {
+        return function() {
+          if (modalWindow) {
+              modalWindow.removeEventListener('unload', onUnload, false);
+              modalWindow.close();
+          }
+          // checking if prompt
+          var promptInput = modalDocument.getElementById('prompt-input');
+          var response;
+          if (promptInput) {
+              response = {
+                input1: promptInput.value,
+                buttonIndex: labelIndex
+              };
+          }
+          response = response || labelIndex;
+          callback(response);
+        }
+    }
+}
+
+var Notification = {
+    vibrate: function(milliseconds) {
+        navigator.vibrate(milliseconds);
+    },
+    alert: function(successCallback, errorCallback, args) {
+        var message = args[0];
+        var title = args[1];
+        var _buttonLabels = [args[2]];
+        var _callback = (successCallback || _empty);
+        modal(message, _callback, title, _buttonLabels);
+    },
+    confirm: function(successCallback, errorCallback, args) {
+        var message = args[0];
+        var title = args[1];
+        var buttonLabels = args[2];
+        var _callback = (successCallback || _empty);
+        modal(message, _callback, title, buttonLabels);
+    },
+    prompt: function(successCallback, errorCallback, args) {
+        var message = args[0];
+        var title = args[1];
+        var buttonLabels = args[2];
+        var defaultText = args[3];
+        var inputParagraph = document.createElement('p');
+        inputParagraph.classList.add('input');
+        var inputElement = document.createElement('input');
+        inputElement.setAttribute('type', 'text');
+        inputElement.id = 'prompt-input';
+        if (defaultText) {
+            inputElement.setAttribute('placeholder', defaultText);
+        }
+        inputParagraph.appendChild(inputElement);
+        modal(message, successCallback, title, buttonLabels, inputParagraph);
+    }
+};
+
+
+module.exports = Notification;
+require('cordova/exec/proxy').add('Notification', Notification);
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.dialogs/www/notification.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.dialogs/www/notification.js
@@ -1,0 +1,113 @@
+cordova.define("org.apache.cordova.dialogs.notification", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var exec = require('cordova/exec');
+var platform = require('cordova/platform');
+
+/**
+ * Provides access to notifications on the device.
+ */
+
+module.exports = {
+
+    /**
+     * Open a native alert dialog, with a customizable title and button text.
+     *
+     * @param {String} message              Message to print in the body of the alert
+     * @param {Function} completeCallback   The callback that is called when user clicks on a button.
+     * @param {String} title                Title of the alert dialog (default: Alert)
+     * @param {String} buttonLabel          Label of the close button (default: OK)
+     */
+    alert: function(message, completeCallback, title, buttonLabel) {
+        var _title = (title || "Alert");
+        var _buttonLabel = (buttonLabel || "OK");
+        exec(completeCallback, null, "Notification", "alert", [message, _title, _buttonLabel]);
+    },
+
+    /**
+     * Open a native confirm dialog, with a customizable title and button text.
+     * The result that the user selects is returned to the result callback.
+     *
+     * @param {String} message              Message to print in the body of the alert
+     * @param {Function} resultCallback     The callback that is called when user clicks on a button.
+     * @param {String} title                Title of the alert dialog (default: Confirm)
+     * @param {Array} buttonLabels          Array of the labels of the buttons (default: ['OK', 'Cancel'])
+     */
+    confirm: function(message, resultCallback, title, buttonLabels) {
+        var _title = (title || "Confirm");
+        var _buttonLabels = (buttonLabels || ["OK", "Cancel"]);
+
+        // Strings are deprecated!
+        if (typeof _buttonLabels === 'string') {
+            console.log("Notification.confirm(string, function, string, string) is deprecated.  Use Notification.confirm(string, function, string, array).");
+        }
+
+        // Some platforms take an array of button label names.
+        // Other platforms take a comma separated list.
+        // For compatibility, we convert to the desired type based on the platform.
+        if (platform.id == "amazon-fireos" || platform.id == "android" || platform.id == "ios" || platform.id == "windowsphone" || platform.id == "firefoxos" || platform.id == "ubuntu") {
+
+            if (typeof _buttonLabels === 'string') {
+                var buttonLabelString = _buttonLabels;
+                _buttonLabels = _buttonLabels.split(","); // not crazy about changing the var type here
+            }
+        } else {
+            if (Array.isArray(_buttonLabels)) {
+                var buttonLabelArray = _buttonLabels;
+                _buttonLabels = buttonLabelArray.toString();
+            }
+        }
+        exec(resultCallback, null, "Notification", "confirm", [message, _title, _buttonLabels]);
+    },
+
+    /**
+     * Open a native prompt dialog, with a customizable title and button text.
+     * The following results are returned to the result callback:
+     *  buttonIndex     Index number of the button selected.
+     *  input1          The text entered in the prompt dialog box.
+     *
+     * @param {String} message              Dialog message to display (default: "Prompt message")
+     * @param {Function} resultCallback     The callback that is called when user clicks on a button.
+     * @param {String} title                Title of the dialog (default: "Prompt")
+     * @param {Array} buttonLabels          Array of strings for the button labels (default: ["OK","Cancel"])
+     * @param {String} defaultText          Textbox input value (default: empty string)
+     */
+    prompt: function(message, resultCallback, title, buttonLabels, defaultText) {
+        var _message = (message || "Prompt message");
+        var _title = (title || "Prompt");
+        var _buttonLabels = (buttonLabels || ["OK","Cancel"]);
+        var _defaultText = (defaultText || "");
+        exec(resultCallback, null, "Notification", "prompt", [_message, _title, _buttonLabels, _defaultText]);
+    },
+
+    /**
+     * Causes the device to beep.
+     * On Android, the default notification ringtone is played "count" times.
+     *
+     * @param {Integer} count       The number of beeps.
+     */
+    beep: function(count) {
+        var defaultedCount = count || 1;
+        exec(null, null, "Notification", "beep", [ defaultedCount ]);
+    }
+};
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file-transfer/www/FileTransfer.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file-transfer/www/FileTransfer.js
@@ -1,0 +1,214 @@
+cordova.define("org.apache.cordova.file-transfer.FileTransfer", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    exec = require('cordova/exec'),
+    FileTransferError = require('./FileTransferError'),
+    ProgressEvent = require('org.apache.cordova.file.ProgressEvent');
+
+function newProgressEvent(result) {
+    var pe = new ProgressEvent();
+    pe.lengthComputable = result.lengthComputable;
+    pe.loaded = result.loaded;
+    pe.total = result.total;
+    return pe;
+}
+
+function getUrlCredentials(urlString) {
+    var credentialsPattern = /^http\:\/\/((.*?)\:(.*?))@.*$/g,
+        credentials = credentialsPattern.exec(urlString);
+
+    return credentials && credentials[1];
+}
+
+function getBasicAuthHeader(urlString) {
+    var header =  null;
+
+
+    // This is changed due to MS Windows doesn't support credentials in http uris
+    // so we detect them by regexp and strip off from result url
+    // Proof: http://social.msdn.microsoft.com/Forums/windowsapps/en-US/a327cf3c-f033-4a54-8b7f-03c56ba3203f/windows-foundation-uri-security-problem
+
+    if (window.btoa) {
+        var credentials = getUrlCredentials(urlString);
+        if (credentials) {
+            var authHeader = "Authorization";
+            var authHeaderValue = "Basic " + window.btoa(credentials);
+
+            header = {
+                name : authHeader,
+                value : authHeaderValue
+            };
+        }
+    }
+
+    return header;
+}
+
+var idCounter = 0;
+
+/**
+ * FileTransfer uploads a file to a remote server.
+ * @constructor
+ */
+var FileTransfer = function() {
+    this._id = ++idCounter;
+    this.onprogress = null; // optional callback
+};
+
+/**
+* Given an absolute file path, uploads a file on the device to a remote server
+* using a multipart HTTP request.
+* @param filePath {String}           Full path of the file on the device
+* @param server {String}             URL of the server to receive the file
+* @param successCallback (Function}  Callback to be invoked when upload has completed
+* @param errorCallback {Function}    Callback to be invoked upon error
+* @param options {FileUploadOptions} Optional parameters such as file name and mimetype
+* @param trustAllHosts {Boolean} Optional trust all hosts (e.g. for self-signed certs), defaults to false
+*/
+FileTransfer.prototype.upload = function(filePath, server, successCallback, errorCallback, options, trustAllHosts) {
+    argscheck.checkArgs('ssFFO*', 'FileTransfer.upload', arguments);
+    // check for options
+    var fileKey = null;
+    var fileName = null;
+    var mimeType = null;
+    var params = null;
+    var chunkedMode = true;
+    var headers = null;
+    var httpMethod = null;
+    var basicAuthHeader = getBasicAuthHeader(server);
+    if (basicAuthHeader) {
+        server = server.replace(getUrlCredentials(server) + '@', '');
+
+        options = options || {};
+        options.headers = options.headers || {};
+        options.headers[basicAuthHeader.name] = basicAuthHeader.value;
+    }
+
+    if (options) {
+        fileKey = options.fileKey;
+        fileName = options.fileName;
+        mimeType = options.mimeType;
+        headers = options.headers;
+        httpMethod = options.httpMethod || "POST";
+        if (httpMethod.toUpperCase() == "PUT"){
+            httpMethod = "PUT";
+        } else {
+            httpMethod = "POST";
+        }
+        if (options.chunkedMode !== null || typeof options.chunkedMode != "undefined") {
+            chunkedMode = options.chunkedMode;
+        }
+        if (options.params) {
+            params = options.params;
+        }
+        else {
+            params = {};
+        }
+    }
+
+    var fail = errorCallback && function(e) {
+        var error = new FileTransferError(e.code, e.source, e.target, e.http_status, e.body, e.exception);
+        errorCallback(error);
+    };
+
+    var self = this;
+    var win = function(result) {
+        if (typeof result.lengthComputable != "undefined") {
+            if (self.onprogress) {
+                self.onprogress(newProgressEvent(result));
+            }
+        } else {
+            successCallback && successCallback(result);
+        }
+    };
+    exec(win, fail, 'FileTransfer', 'upload', [filePath, server, fileKey, fileName, mimeType, params, trustAllHosts, chunkedMode, headers, this._id, httpMethod]);
+};
+
+/**
+ * Downloads a file form a given URL and saves it to the specified directory.
+ * @param source {String}          URL of the server to receive the file
+ * @param target {String}         Full path of the file on the device
+ * @param successCallback (Function}  Callback to be invoked when upload has completed
+ * @param errorCallback {Function}    Callback to be invoked upon error
+ * @param trustAllHosts {Boolean} Optional trust all hosts (e.g. for self-signed certs), defaults to false
+ * @param options {FileDownloadOptions} Optional parameters such as headers
+ */
+FileTransfer.prototype.download = function(source, target, successCallback, errorCallback, trustAllHosts, options) {
+    argscheck.checkArgs('ssFF*', 'FileTransfer.download', arguments);
+    var self = this;
+
+    var basicAuthHeader = getBasicAuthHeader(source);
+    if (basicAuthHeader) {
+        source = source.replace(getUrlCredentials(source) + '@', '');
+
+        options = options || {};
+        options.headers = options.headers || {};
+        options.headers[basicAuthHeader.name] = basicAuthHeader.value;
+    }
+
+    var headers = null;
+    if (options) {
+        headers = options.headers || null;
+    }
+
+    var win = function(result) {
+        if (typeof result.lengthComputable != "undefined") {
+            if (self.onprogress) {
+                return self.onprogress(newProgressEvent(result));
+            }
+        } else if (successCallback) {
+            var entry = null;
+            if (result.isDirectory) {
+                entry = new (require('org.apache.cordova.file.DirectoryEntry'))();
+            }
+            else if (result.isFile) {
+                entry = new (require('org.apache.cordova.file.FileEntry'))();
+            }
+            entry.isDirectory = result.isDirectory;
+            entry.isFile = result.isFile;
+            entry.name = result.name;
+            entry.fullPath = result.fullPath;
+            entry.filesystem = new FileSystem(result.filesystemName || (result.filesystem == window.PERSISTENT ? 'persistent' : 'temporary'));
+            entry.nativeURL = result.nativeURL;
+            successCallback(entry);
+        }
+    };
+
+    var fail = errorCallback && function(e) {
+        var error = new FileTransferError(e.code, e.source, e.target, e.http_status, e.body, e.exception);
+        errorCallback(error);
+    };
+
+    exec(win, fail, 'FileTransfer', 'download', [source, target, trustAllHosts, this._id, headers]);
+};
+
+/**
+ * Aborts the ongoing file transfer on this object. The original error
+ * callback for the file transfer will be called if necessary.
+ */
+FileTransfer.prototype.abort = function() {
+    exec(null, null, 'FileTransfer', 'abort', [this._id]);
+};
+
+module.exports = FileTransfer;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file-transfer/www/FileTransferError.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file-transfer/www/FileTransferError.js
@@ -1,0 +1,43 @@
+cordova.define("org.apache.cordova.file-transfer.FileTransferError", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * FileTransferError
+ * @constructor
+ */
+var FileTransferError = function(code, source, target, status, body, exception) {
+    this.code = code || null;
+    this.source = source || null;
+    this.target = target || null;
+    this.http_status = status || null;
+    this.body = body || null;
+    this.exception = exception || null;
+};
+
+FileTransferError.FILE_NOT_FOUND_ERR = 1;
+FileTransferError.INVALID_URL_ERR = 2;
+FileTransferError.CONNECTION_ERR = 3;
+FileTransferError.ABORT_ERR = 4;
+FileTransferError.NOT_MODIFIED_ERR = 5;
+
+module.exports = FileTransferError;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file-transfer/www/firefoxos/FileTransferProxy.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file-transfer/www/firefoxos/FileTransferProxy.js
@@ -1,0 +1,225 @@
+cordova.define("org.apache.cordova.file-transfer.FileTransferProxy", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var cordova = require('cordova'),
+    FileTransferError = require('./FileTransferError'),
+    xhr = {};
+
+function getParentPath(filePath) {
+    var pos = filePath.lastIndexOf('/');
+    return filePath.substring(0, pos + 1);
+}
+
+function getFileName(filePath) {
+    var pos = filePath.lastIndexOf('/');
+    return filePath.substring(pos + 1);
+}
+
+module.exports = {
+    abort: function (successCallback, errorCallback, args) {
+        var id = args[0];
+        if (xhr[id]) {
+            xhr[id].abort();
+            if (typeof(successCallback) === 'function') {
+                successCallback();
+            }
+        } else if (typeof(errorCallback) === 'function') {
+            errorCallback();
+        }
+    },
+
+    upload: function(successCallback, errorCallback, args) {
+        var filePath = args[0],
+            server = args[1],
+            fileKey = args[9],
+            fileName = args[3],
+            mimeType = args[4],
+            params = args[5],
+            /*trustAllHosts = args[6],*/
+            /*chunkedMode = args[7],*/
+            headers = args[8];
+
+        xhr[fileKey] = new XMLHttpRequest({mozSystem: true});
+        xhr[fileKey].onabort = function() {
+            onFail(new FileTransferError(FileTransferError.ABORT_ERR, server, filePath, this.status, xhr[fileKey].response));
+        };
+
+        window.resolveLocalFileSystemURL(filePath, function(entry) {
+            entry.file(function(file) {
+                var reader = new FileReader();
+
+                reader.onloadend = function() {
+                    var blob = new Blob([this.result], {type: mimeType});
+                    var fd = new FormData();
+
+                    fd.append(fileKey, blob, fileName);
+
+                    for (var prop in params) {
+                        if (params.hasOwnProperty(prop)) {
+                            fd.append(prop, params[prop]);
+                        }
+                    }
+
+                    xhr[fileKey].open("POST", server);
+
+                    xhr[fileKey].onload = function(evt) {
+                        if (xhr[fileKey].status === 200) {
+                            var result = new FileUploadResult();
+                            result.bytesSent = blob.size;
+                            result.responseCode = xhr[fileKey].status;
+                            result.response = xhr[fileKey].response;
+                            delete xhr[fileKey];
+                            onSuccess(result);
+                        } else if (xhr[fileKey].status === 404) {
+                            onFail(new FileTransferError(FileTransferError.INVALID_URL_ERR, server, filePath, xhr[fileKey].status, xhr[fileKey].response));
+                        } else {
+                            onFail(new FileTransferError(FileTransferError.CONNECTION_ERR, server, filePath, xhr[fileKey].status, xhr[fileKey].response));
+                        }
+                    };
+
+                    xhr[fileKey].ontimeout = function() {
+                        onFail(new FileTransferError(FileTransferError.CONNECTION_ERR, server, filePath, xhr[fileKey].status, xhr[fileKey].response));
+                    };
+
+                    xhr[fileKey].onerror = function() {
+                        onFail(new FileTransferError(FileTransferError.CONNECTION_ERR, server, filePath, this.status, xhr[fileKey].response));
+                    };
+
+                    for (var header in headers) {
+                        if (headers.hasOwnProperty(header)) {
+                            xhr[fileKey].setRequestHeader(header, headers[header]);
+                        }
+                    }
+
+                    xhr[fileKey].send(fd);
+                };
+
+                reader.readAsArrayBuffer(file);
+
+            }, function() {
+                onFail(new FileTransferError(FileTransferError.FILE_NOT_FOUND_ERR, server, filePath));
+            });
+        }, function() {
+            onFail(new FileTransferError(FileTransferError.FILE_NOT_FOUND_ERR, server, filePath));
+        });
+
+        function onSuccess(data) {
+            if (typeof(successCallback) === 'function') {
+                successCallback(data);
+            }
+        }
+
+        function onFail(code) {
+            delete xhr[fileKey];
+            if (typeof(errorCallback) === 'function') {
+                errorCallback(code);
+            }
+        }
+    },
+
+    download: function (successCallback, errorCallback, args) {
+        var source = args[0],
+            target = args[1],
+            id = args[3],
+            headers = args[4];
+
+        xhr[id] = new XMLHttpRequest({mozSystem: true});
+
+        xhr[id].onload = function () {
+            if (xhr[id].readyState === xhr[id].DONE) {
+                if (xhr[id].status === 200 && xhr[id].response) {
+                    window.resolveLocalFileSystemURL(getParentPath(target), function (dir) {
+                        dir.getFile(getFileName(target), {create: true}, writeFile, function (error) {
+                            onFail(new FileTransferError(FileTransferError.FILE_NOT_FOUND_ERR, source, target, xhr[id].status, xhr[id].response));
+                        });
+                    }, function () {
+                        onFail(new FileTransferError(FileTransferError.FILE_NOT_FOUND_ERR, source, target, xhr[id].status, xhr[id].response));
+                    });
+                } else if (xhr[id].status === 404) {
+                    onFail(new FileTransferError(FileTransferError.INVALID_URL_ERR, source, target, xhr[id].status, xhr[id].response));
+                } else {
+                    onFail(new FileTransferError(FileTransferError.CONNECTION_ERR, source, target, xhr[id].status, xhr[id].response));
+                }
+            }
+        };
+
+        function writeFile(entry) {
+            entry.createWriter(function (fileWriter) {
+                fileWriter.onwriteend = function (evt) {
+                    if (!evt.target.error) {
+                        entry.filesystemName = entry.filesystem.name;
+                        delete xhr[id];
+                        onSuccess(entry);
+                    } else {
+                        onFail(evt.target.error);
+                    }
+                };
+                fileWriter.onerror = function (evt) {
+                    onFail(evt.target.error);
+                };
+                fileWriter.write(new Blob([xhr[id].response]));
+            }, function (error) {
+                onFail(error);
+            });
+        }
+
+        xhr[id].onerror = function (e) {
+            onFail(new FileTransferError(FileTransferError.CONNECTION_ERR, source, target, xhr[id].status, xhr[id].response));
+        };
+
+        xhr[id].onabort = function (e) {
+            onFail(new FileTransferError(FileTransferError.ABORT_ERR, source, target, xhr[id].status, xhr[id].response));
+        };
+
+        xhr[id].open("GET", source, true);
+
+        for (var header in headers) {
+            if (headers.hasOwnProperty(header)) {
+                xhr[id].setRequestHeader(header, headers[header]);
+            }
+        }
+
+        xhr[id].responseType = "blob";
+
+        setTimeout(function () {
+            if (xhr[id]) {
+                xhr[id].send();
+            }
+        }, 0);
+
+        function onSuccess(entry) {
+            if (typeof(successCallback) === 'function') {
+                successCallback(entry);
+            }
+        }
+
+        function onFail(error) {
+            delete xhr[id];
+            if (typeof(errorCallback) === 'function') {
+                errorCallback(error);
+            }
+        }
+    }
+};
+
+require('cordova/exec/proxy').add('FileTransfer', module.exports);
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/src/firefoxos/FileProxy.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/src/firefoxos/FileProxy.js
@@ -1,0 +1,787 @@
+cordova.define("org.apache.cordova.file.FileProxy", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+var LocalFileSystem = require('./LocalFileSystem'),
+    FileSystem = require('./FileSystem'),
+    FileEntry = require('./FileEntry'),
+    FileError = require('./FileError'),
+    DirectoryEntry = require('./DirectoryEntry'),
+    File = require('./File');
+
+/*
+QUIRKS:
+    Does not fail when removing non-empty directories
+    Does not support metadata for directories
+    Does not support requestAllFileSystems
+    Does not support resolveLocalFileSystemURI
+    Methods copyTo and moveTo do not support directories
+
+    Heavily based on https://github.com/ebidel/idb.filesystem.js
+ */
+
+
+(function(exports, global) {
+    var indexedDB = global.indexedDB || global.mozIndexedDB;
+    if (!indexedDB) {
+        throw "Firefox OS File plugin: indexedDB not supported";
+    }
+
+    var fs_ = null;
+
+    var idb_ = {};
+    idb_.db = null;
+    var FILE_STORE_ = 'entries';
+
+    var DIR_SEPARATOR = '/';
+    var DIR_OPEN_BOUND = String.fromCharCode(DIR_SEPARATOR.charCodeAt(0) + 1);
+
+    var pathsPrefix = {
+        // Read-only directory where the application is installed.
+        applicationDirectory: location.origin + "/",
+        // Where to put app-specific data files.
+        dataDirectory: 'file:///persistent/',
+        // Cached files that should survive app restarts.
+        // Apps should not rely on the OS to delete files in here.
+        cacheDirectory: 'file:///temporary/',
+    };
+
+/*** Exported functionality ***/
+
+    exports.requestFileSystem = function(successCallback, errorCallback, args) {
+        var type = args[0];
+        var size = args[1];
+
+        if (type !== LocalFileSystem.TEMPORARY && type !== LocalFileSystem.PERSISTENT) {
+            errorCallback && errorCallback(FileError.INVALID_MODIFICATION_ERR);
+            return;
+        }
+
+        var name = type === LocalFileSystem.TEMPORARY ? 'temporary' : 'persistent';
+        var storageName = (location.protocol + location.host).replace(/:/g, '_');
+
+        var root = new DirectoryEntry('', DIR_SEPARATOR);
+        fs_ = new FileSystem(name, root);
+
+        idb_.open(storageName, function() {
+            successCallback(fs_);
+        }, errorCallback);
+    };
+
+    require('./fileSystems').getFs = function(name, callback) {
+        callback(new FileSystem(name, fs_.root));
+    };
+
+    // list a directory's contents (files and folders).
+    exports.readEntries = function(successCallback, errorCallback, args) {
+        var fullPath = args[0];
+
+        if (!successCallback) {
+            throw Error('Expected successCallback argument.');
+        }
+
+        var path = resolveToFullPath_(fullPath);
+
+        idb_.getAllEntries(path.fullPath, path.storagePath, function(entries) {
+            successCallback(entries);
+        }, errorCallback);
+    };
+
+    exports.getFile = function(successCallback, errorCallback, args) {
+        var fullPath = args[0];
+        var path = args[1];
+        var options = args[2] || {};
+
+        // Create an absolute path if we were handed a relative one.
+        path = resolveToFullPath_(fullPath, path);
+
+        idb_.get(path.storagePath, function(fileEntry) {
+            if (options.create === true && options.exclusive === true && fileEntry) {
+                // If create and exclusive are both true, and the path already exists,
+                // getFile must fail.
+
+                if (errorCallback) {
+                    errorCallback(FileError.PATH_EXISTS_ERR);
+                }
+            } else if (options.create === true && !fileEntry) {
+                // If create is true, the path doesn't exist, and no other error occurs,
+                // getFile must create it as a zero-length file and return a corresponding
+                // FileEntry.
+                var newFileEntry = new FileEntry(path.fileName, path.fullPath, new FileSystem(path.fsName, fs_.root));
+
+                newFileEntry.file_ = new MyFile({
+                    size: 0,
+                    name: newFileEntry.name,
+                    lastModifiedDate: new Date(),
+                    storagePath: path.storagePath
+                });
+
+                idb_.put(newFileEntry, path.storagePath, successCallback, errorCallback);
+            } else if (options.create === true && fileEntry) {
+                if (fileEntry.isFile) {
+                    // Overwrite file, delete then create new.
+                    idb_['delete'](path.storagePath, function() {
+                        var newFileEntry = new FileEntry(path.fileName, path.fullPath, new FileSystem(path.fsName, fs_.root));
+
+                        newFileEntry.file_ = new MyFile({
+                            size: 0,
+                            name: newFileEntry.name,
+                            lastModifiedDate: new Date(),
+                            storagePath: path.storagePath
+                        });
+
+                        idb_.put(newFileEntry, path.storagePath, successCallback, errorCallback);
+                    }, errorCallback);
+                } else {
+                    if (errorCallback) {
+                        errorCallback(FileError.INVALID_MODIFICATION_ERR);
+                    }
+                }
+            } else if ((!options.create || options.create === false) && !fileEntry) {
+                // If create is not true and the path doesn't exist, getFile must fail.
+                if (errorCallback) {
+                    errorCallback(FileError.NOT_FOUND_ERR);
+                }
+            } else if ((!options.create || options.create === false) && fileEntry &&
+                fileEntry.isDirectory) {
+                // If create is not true and the path exists, but is a directory, getFile
+                // must fail.
+                if (errorCallback) {
+                    errorCallback(FileError.INVALID_MODIFICATION_ERR);
+                }
+            } else {
+                // Otherwise, if no other error occurs, getFile must return a FileEntry
+                // corresponding to path.
+
+                successCallback(fileEntryFromIdbEntry(fileEntry));
+            }
+        }, errorCallback);
+    };
+
+    exports.getFileMetadata = function(successCallback, errorCallback, args) {
+        var fullPath = args[0];
+
+        exports.getFile(function(fileEntry) {
+            successCallback(new File(fileEntry.file_.name, fileEntry.fullPath, '', fileEntry.file_.lastModifiedDate,
+                fileEntry.file_.size));
+        }, errorCallback, [fullPath, null]);
+    };
+
+    exports.getMetadata = function(successCallback, errorCallback, args) {
+        exports.getFile(function (fileEntry) {
+            successCallback(
+                {
+                    modificationTime: fileEntry.file_.lastModifiedDate,
+                    size: fileEntry.file_.lastModifiedDate
+                });
+        }, errorCallback, args);
+    };
+
+    exports.setMetadata = function(successCallback, errorCallback, args) {
+        var fullPath = args[0];
+        var metadataObject = args[1];
+
+        exports.getFile(function (fileEntry) {
+              fileEntry.file_.lastModifiedDate = metadataObject.modificationTime;
+        }, errorCallback, [fullPath, null]);
+    };
+
+    exports.write = function(successCallback, errorCallback, args) {
+        var fileName = args[0],
+            data = args[1],
+            position = args[2],
+            isBinary = args[3];
+
+        if (!data) {
+            errorCallback && errorCallback(FileError.INVALID_MODIFICATION_ERR);
+            return;
+        }
+
+        exports.getFile(function(fileEntry) {
+            var blob_ = fileEntry.file_.blob_;
+
+            if (!blob_) {
+                blob_ = new Blob([data], {type: data.type});
+            } else {
+                // Calc the head and tail fragments
+                var head = blob_.slice(0, position);
+                var tail = blob_.slice(position + data.byteLength);
+
+                // Calc the padding
+                var padding = position - head.size;
+                if (padding < 0) {
+                    padding = 0;
+                }
+
+                // Do the "write". In fact, a full overwrite of the Blob.
+                blob_ = new Blob([head, new Uint8Array(padding), data, tail],
+                    {type: data.type});
+            }
+
+            // Set the blob we're writing on this file entry so we can recall it later.
+            fileEntry.file_.blob_ = blob_;
+            fileEntry.file_.lastModifiedDate = data.lastModifiedDate || null;
+            fileEntry.file_.size = blob_.size;
+            fileEntry.file_.name = blob_.name;
+            fileEntry.file_.type = blob_.type;
+
+            idb_.put(fileEntry, fileEntry.file_.storagePath, function() {
+                successCallback(data.byteLength);
+            }, errorCallback);
+        }, errorCallback, [fileName, null]);
+    };
+
+    exports.readAsText = function(successCallback, errorCallback, args) {
+        var fileName = args[0],
+            enc = args[1],
+            startPos = args[2],
+            endPos = args[3];
+
+        readAs('text', fileName, enc, startPos, endPos, successCallback, errorCallback);
+    };
+
+    exports.readAsDataURL = function(successCallback, errorCallback, args) {
+        var fileName = args[0],
+            startPos = args[1],
+            endPos = args[2];
+
+        readAs('dataURL', fileName, null, startPos, endPos, successCallback, errorCallback);
+    };
+
+    exports.readAsBinaryString = function(successCallback, errorCallback, args) {
+        var fileName = args[0],
+            startPos = args[1],
+            endPos = args[2];
+
+        readAs('binaryString', fileName, null, startPos, endPos, successCallback, errorCallback);
+    };
+
+    exports.readAsArrayBuffer = function(successCallback, errorCallback, args) {
+        var fileName = args[0],
+            startPos = args[1],
+            endPos = args[2];
+
+        readAs('arrayBuffer', fileName, null, startPos, endPos, successCallback, errorCallback);
+    };
+
+    exports.removeRecursively = exports.remove = function(successCallback, errorCallback, args) {
+        var fullPath = args[0];
+
+        // TODO: This doesn't protect against directories that have content in it.
+        // Should throw an error instead if the dirEntry is not empty.
+        idb_['delete'](fullPath, function() {
+            successCallback();
+        }, errorCallback);
+    };
+
+    exports.getDirectory = function(successCallback, errorCallback, args) {
+        var fullPath = args[0];
+        var path = args[1];
+        var options = args[2];
+
+        // Create an absolute path if we were handed a relative one.
+        path = resolveToFullPath_(fullPath, path);
+
+        idb_.get(path.storagePath, function(folderEntry) {
+            if (!options) {
+                options = {};
+            }
+
+            if (options.create === true && options.exclusive === true && folderEntry) {
+                // If create and exclusive are both true, and the path already exists,
+                // getDirectory must fail.
+                if (errorCallback) {
+                    errorCallback(FileError.INVALID_MODIFICATION_ERR);
+                }
+            } else if (options.create === true && !folderEntry) {
+                // If create is true, the path doesn't exist, and no other error occurs,
+                // getDirectory must create it as a zero-length file and return a corresponding
+                // MyDirectoryEntry.
+                var dirEntry = new DirectoryEntry(path.fileName, path.fullPath, new FileSystem(path.fsName, fs_.root));
+
+                idb_.put(dirEntry, path.storagePath, successCallback, errorCallback);
+            } else if (options.create === true && folderEntry) {
+
+                if (folderEntry.isDirectory) {
+                    // IDB won't save methods, so we need re-create the MyDirectoryEntry.
+                    successCallback(new DirectoryEntry(folderEntry.name, folderEntry.fullPath, folderEntry.fileSystem));
+                } else {
+                    if (errorCallback) {
+                        errorCallback(FileError.INVALID_MODIFICATION_ERR);
+                    }
+                }
+            } else if ((!options.create || options.create === false) && !folderEntry) {
+                // Handle root special. It should always exist.
+                if (path.fullPath === DIR_SEPARATOR) {
+                    successCallback(fs_.root);
+                    return;
+                }
+
+                // If create is not true and the path doesn't exist, getDirectory must fail.
+                if (errorCallback) {
+                    errorCallback(FileError.NOT_FOUND_ERR);
+                }
+            } else if ((!options.create || options.create === false) && folderEntry &&
+                folderEntry.isFile) {
+                // If create is not true and the path exists, but is a file, getDirectory
+                // must fail.
+                if (errorCallback) {
+                    errorCallback(FileError.INVALID_MODIFICATION_ERR);
+                }
+            } else {
+                // Otherwise, if no other error occurs, getDirectory must return a
+                // MyDirectoryEntry corresponding to path.
+
+                // IDB won't' save methods, so we need re-create MyDirectoryEntry.
+                successCallback(new DirectoryEntry(folderEntry.name, folderEntry.fullPath, folderEntry.fileSystem));
+            }
+        }, errorCallback);
+    };
+
+    exports.getParent = function(successCallback, errorCallback, args) {
+        var fullPath = args[0];
+
+        if (fullPath === DIR_SEPARATOR) {
+            successCallback(fs_.root);
+            return;
+        }
+
+        var pathArr = fullPath.split(DIR_SEPARATOR);
+        pathArr.pop();
+        var namesa = pathArr.pop();
+        var path = pathArr.join(DIR_SEPARATOR);
+
+        exports.getDirectory(successCallback, errorCallback, [path, namesa, {create: false}]);
+    };
+
+    exports.copyTo = function(successCallback, errorCallback, args) {
+        var srcPath = args[0];
+        var parentFullPath = args[1];
+        var name = args[2];
+
+        // Read src file
+        exports.getFile(function(srcFileEntry) {
+
+            // Create dest file
+            exports.getFile(function(dstFileEntry) {
+
+                exports.write(function() {
+                    successCallback(dstFileEntry);
+                }, errorCallback, [dstFileEntry.file_.storagePath, srcFileEntry.file_.blob_, 0]);
+
+            }, errorCallback, [parentFullPath, name, {create: true}]);
+
+        }, errorCallback, [srcPath, null]);
+    };
+
+    exports.moveTo = function(successCallback, errorCallback, args) {
+        var srcPath = args[0];
+        var parentFullPath = args[1];
+        var name = args[2];
+
+        exports.copyTo(function (fileEntry) {
+
+            exports.remove(function () {
+                successCallback(fileEntry);
+            }, errorCallback, [srcPath]);
+
+        }, errorCallback, args);
+    };
+
+    exports.resolveLocalFileSystemURI = function(successCallback, errorCallback, args) {
+        var path = args[0];
+
+        // Ignore parameters
+        if (path.indexOf('?') !== -1) {
+            path = String(path).split("?")[0];
+        }
+
+        // support for encodeURI
+        if (/\%5/g.test(path)) {
+            path = decodeURI(path);
+        }
+
+        if (path.indexOf(pathsPrefix.dataDirectory) === 0) {
+            path = path.substring(pathsPrefix.dataDirectory.length - 1);
+
+            exports.requestFileSystem(function(fs) {
+                fs.root.getFile(path, {create: false}, successCallback, function() {
+                    fs.root.getDirectory(path, {create: false}, successCallback, errorCallback);
+                });
+            }, errorCallback, [LocalFileSystem.PERSISTENT]);
+        } else if (path.indexOf(pathsPrefix.cacheDirectory) === 0) {
+            path = path.substring(pathsPrefix.cacheDirectory.length - 1);
+
+            exports.requestFileSystem(function(fs) {
+                fs.root.getFile(path, {create: false}, successCallback, function() {
+                    fs.root.getDirectory(path, {create: false}, successCallback, errorCallback);
+                });
+            }, errorCallback, [LocalFileSystem.TEMPORARY]);
+        } else if (path.indexOf(pathsPrefix.applicationDirectory) === 0) {
+            path = path.substring(pathsPrefix.applicationDirectory.length);
+
+            var xhr = new XMLHttpRequest();
+            xhr.open("GET", path, true);
+            xhr.onreadystatechange = function () {
+                if (xhr.status === 200 && xhr.readyState === 4) {
+                    exports.requestFileSystem(function(fs) {
+                        fs.name = location.hostname;
+                        fs.root.getFile(path, {create: true}, writeFile, errorCallback);
+                    }, errorCallback, [LocalFileSystem.PERSISTENT]);
+                }
+            };
+
+            xhr.onerror = function () {
+                errorCallback && errorCallback(FileError.NOT_READABLE_ERR);
+            };
+
+            xhr.send();
+        } else {
+            errorCallback && errorCallback(FileError.NOT_FOUND_ERR);
+        }
+
+        function writeFile(entry) {
+            entry.createWriter(function (fileWriter) {
+                fileWriter.onwriteend = function (evt) {
+                    if (!evt.target.error) {
+                        entry.filesystemName = location.hostname;
+                        successCallback(entry);
+                    }
+                };
+                fileWriter.onerror = function () {
+                    errorCallback && errorCallback(FileError.NOT_READABLE_ERR);
+                };
+                fileWriter.write(new Blob([xhr.response]));
+            }, errorCallback);
+        }
+    };
+
+    exports.requestAllPaths = function(successCallback) {
+        successCallback(pathsPrefix);
+    };
+
+/*** Helpers ***/
+
+    /**
+     * Interface to wrap the native File interface.
+     *
+     * This interface is necessary for creating zero-length (empty) files,
+     * something the Filesystem API allows you to do. Unfortunately, File's
+     * constructor cannot be called directly, making it impossible to instantiate
+     * an empty File in JS.
+     *
+     * @param {Object} opts Initial values.
+     * @constructor
+     */
+    function MyFile(opts) {
+        var blob_ = new Blob();
+
+        this.size = opts.size || 0;
+        this.name = opts.name || '';
+        this.type = opts.type || '';
+        this.lastModifiedDate = opts.lastModifiedDate || null;
+        this.storagePath = opts.storagePath || '';
+
+        // Need some black magic to correct the object's size/name/type based on the
+        // blob that is saved.
+        Object.defineProperty(this, 'blob_', {
+            enumerable: true,
+            get: function() {
+                return blob_;
+            },
+            set: function(val) {
+                blob_ = val;
+                this.size = blob_.size;
+                this.name = blob_.name;
+                this.type = blob_.type;
+                this.lastModifiedDate = blob_.lastModifiedDate;
+            }.bind(this)
+        });
+    }
+
+    MyFile.prototype.constructor = MyFile;
+
+    // When saving an entry, the fullPath should always lead with a slash and never
+    // end with one (e.g. a directory). Also, resolve '.' and '..' to an absolute
+    // one. This method ensures path is legit!
+    function resolveToFullPath_(cwdFullPath, path) {
+        path = path || '';
+        var fullPath = path;
+        var prefix = '';
+
+        cwdFullPath = cwdFullPath || DIR_SEPARATOR;
+        if (cwdFullPath.indexOf(FILESYSTEM_PREFIX) === 0) {
+            prefix = cwdFullPath.substring(0, cwdFullPath.indexOf(DIR_SEPARATOR, FILESYSTEM_PREFIX.length));
+            cwdFullPath = cwdFullPath.substring(cwdFullPath.indexOf(DIR_SEPARATOR, FILESYSTEM_PREFIX.length));
+        }
+
+        var relativePath = path[0] !== DIR_SEPARATOR;
+        if (relativePath) {
+            fullPath = cwdFullPath;
+            if (cwdFullPath != DIR_SEPARATOR) {
+                fullPath += DIR_SEPARATOR + path;
+            } else {
+                fullPath += path;
+            }
+        }
+
+        // Adjust '..'s by removing parent directories when '..' flows in path.
+        var parts = fullPath.split(DIR_SEPARATOR);
+        for (var i = 0; i < parts.length; ++i) {
+            var part = parts[i];
+            if (part == '..') {
+                parts[i - 1] = '';
+                parts[i] = '';
+            }
+        }
+        fullPath = parts.filter(function(el) {
+            return el;
+        }).join(DIR_SEPARATOR);
+
+        // Add back in leading slash.
+        if (fullPath[0] !== DIR_SEPARATOR) {
+            fullPath = DIR_SEPARATOR + fullPath;
+        }
+
+        // Replace './' by current dir. ('./one/./two' -> one/two)
+        fullPath = fullPath.replace(/\.\//g, DIR_SEPARATOR);
+
+        // Replace '//' with '/'.
+        fullPath = fullPath.replace(/\/\//g, DIR_SEPARATOR);
+
+        // Replace '/.' with '/'.
+        fullPath = fullPath.replace(/\/\./g, DIR_SEPARATOR);
+
+        // Remove '/' if it appears on the end.
+        if (fullPath[fullPath.length - 1] == DIR_SEPARATOR &&
+            fullPath != DIR_SEPARATOR) {
+            fullPath = fullPath.substring(0, fullPath.length - 1);
+        }
+
+        return {
+            storagePath: prefix + fullPath,
+            fullPath: fullPath,
+            fileName: fullPath.split(DIR_SEPARATOR).pop(),
+            fsName: prefix.split(DIR_SEPARATOR).pop()
+        };
+    }
+
+    function fileEntryFromIdbEntry(fileEntry) {
+        // IDB won't save methods, so we need re-create the FileEntry.
+        var clonedFileEntry = new FileEntry(fileEntry.name, fileEntry.fullPath, fileEntry.fileSystem);
+        clonedFileEntry.file_ = fileEntry.file_;
+
+        return clonedFileEntry;
+    }
+
+    function readAs(what, fullPath, encoding, startPos, endPos, successCallback, errorCallback) {
+        exports.getFile(function(fileEntry) {
+            var fileReader = new FileReader(),
+                blob = fileEntry.file_.blob_.slice(startPos, endPos);
+
+            fileReader.onload = function(e) {
+                successCallback(e.target.result);
+            };
+
+            fileReader.onerror = errorCallback;
+
+            switch (what) {
+                case 'text':
+                    fileReader.readAsText(blob, encoding);
+                    break;
+                case 'dataURL':
+                    fileReader.readAsDataURL(blob);
+                    break;
+                case 'arrayBuffer':
+                    fileReader.readAsArrayBuffer(blob);
+                    break;
+                case 'binaryString':
+                    fileReader.readAsBinaryString(blob);
+                    break;
+            }
+
+        }, errorCallback, [fullPath, null]);
+    }
+
+/*** Core logic to handle IDB operations ***/
+
+    idb_.open = function(dbName, successCallback, errorCallback) {
+        var self = this;
+
+        // TODO: FF 12.0a1 isn't liking a db name with : in it.
+        var request = indexedDB.open(dbName.replace(':', '_')/*, 1 /*version*/);
+
+        request.onerror = errorCallback || onError;
+
+        request.onupgradeneeded = function(e) {
+            // First open was called or higher db version was used.
+
+            // console.log('onupgradeneeded: oldVersion:' + e.oldVersion,
+            //           'newVersion:' + e.newVersion);
+
+            self.db = e.target.result;
+            self.db.onerror = onError;
+
+            if (!self.db.objectStoreNames.contains(FILE_STORE_)) {
+                var store = self.db.createObjectStore(FILE_STORE_/*,{keyPath: 'id', autoIncrement: true}*/);
+            }
+        };
+
+        request.onsuccess = function(e) {
+            self.db = e.target.result;
+            self.db.onerror = onError;
+            successCallback(e);
+        };
+
+        request.onblocked = errorCallback || onError;
+    };
+
+    idb_.close = function() {
+        this.db.close();
+        this.db = null;
+    };
+
+    idb_.get = function(fullPath, successCallback, errorCallback) {
+        if (!this.db) {
+            errorCallback && errorCallback(FileError.INVALID_MODIFICATION_ERR);
+            return;
+        }
+
+        var tx = this.db.transaction([FILE_STORE_], 'readonly');
+
+        //var request = tx.objectStore(FILE_STORE_).get(fullPath);
+        var range = IDBKeyRange.bound(fullPath, fullPath + DIR_OPEN_BOUND,
+            false, true);
+        var request = tx.objectStore(FILE_STORE_).get(range);
+
+        tx.onabort = errorCallback || onError;
+        tx.oncomplete = function(e) {
+            successCallback(request.result);
+        };
+    };
+
+    idb_.getAllEntries = function(fullPath, storagePath, successCallback, errorCallback) {
+        if (!this.db) {
+            errorCallback && errorCallback(FileError.INVALID_MODIFICATION_ERR);
+            return;
+        }
+
+        var results = [];
+
+        if (storagePath[storagePath.length - 1] === DIR_SEPARATOR) {
+            storagePath = storagePath.substring(0, storagePath.length - 1);
+        }
+
+        range = IDBKeyRange.bound(
+                storagePath + DIR_SEPARATOR, storagePath + DIR_OPEN_BOUND, false, true);
+
+        var tx = this.db.transaction([FILE_STORE_], 'readonly');
+        tx.onabort = errorCallback || onError;
+        tx.oncomplete = function(e) {
+            results = results.filter(function(val) {
+                var valPartsLen = val.fullPath.split(DIR_SEPARATOR).length;
+                var fullPathPartsLen = fullPath.split(DIR_SEPARATOR).length;
+
+                if (fullPath === DIR_SEPARATOR && valPartsLen < fullPathPartsLen + 1) {
+                    // Hack to filter out entries in the root folder. This is inefficient
+                    // because reading the entires of fs.root (e.g. '/') returns ALL
+                    // results in the database, then filters out the entries not in '/'.
+                    return val;
+                } else if (fullPath !== DIR_SEPARATOR &&
+                    valPartsLen === fullPathPartsLen + 1) {
+                    // If this a subfolder and entry is a direct child, include it in
+                    // the results. Otherwise, it's not an entry of this folder.
+                    return val;
+                }
+            });
+
+            successCallback(results);
+        };
+
+        var request = tx.objectStore(FILE_STORE_).openCursor(range);
+
+        request.onsuccess = function(e) {
+            var cursor = e.target.result;
+            if (cursor) {
+                var val = cursor.value;
+
+                results.push(val.isFile ? fileEntryFromIdbEntry(val) : new DirectoryEntry(val.name, val.fullPath, val.fileSystem));
+                cursor['continue']();
+            }
+        };
+    };
+
+    idb_['delete'] = function(fullPath, successCallback, errorCallback) {
+        if (!this.db) {
+            errorCallback && errorCallback(FileError.INVALID_MODIFICATION_ERR);
+            return;
+        }
+
+        var tx = this.db.transaction([FILE_STORE_], 'readwrite');
+        tx.oncomplete = successCallback;
+        tx.onabort = errorCallback || onError;
+
+        //var request = tx.objectStore(FILE_STORE_).delete(fullPath);
+        var range = IDBKeyRange.bound(
+            fullPath, fullPath + DIR_OPEN_BOUND, false, true);
+        tx.objectStore(FILE_STORE_)['delete'](range);
+    };
+
+    idb_.put = function(entry, storagePath, successCallback, errorCallback) {
+        if (!this.db) {
+            errorCallback && errorCallback(FileError.INVALID_MODIFICATION_ERR);
+            return;
+        }
+
+        var tx = this.db.transaction([FILE_STORE_], 'readwrite');
+        tx.onabort = errorCallback || onError;
+        tx.oncomplete = function(e) {
+            // TODO: Error is thrown if we pass the request event back instead.
+            successCallback(entry);
+        };
+
+        tx.objectStore(FILE_STORE_).put(entry, storagePath);
+    };
+
+    // Global error handler. Errors bubble from request, to transaction, to db.
+    function onError(e) {
+        switch (e.target.errorCode) {
+            case 12:
+                console.log('Error - Attempt to open db with a lower version than the ' +
+                    'current one.');
+                break;
+            default:
+                console.log('errorCode: ' + e.target.errorCode);
+        }
+
+        console.log(e, e.code, e.message);
+    }
+
+// Clean up.
+// TODO: Is there a place for this?
+//    global.addEventListener('beforeunload', function(e) {
+//        idb_.db && idb_.db.close();
+//    }, false);
+
+})(module.exports, window);
+
+require("cordova/exec/proxy").add("File", module.exports);
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/DirectoryEntry.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/DirectoryEntry.js
@@ -1,0 +1,119 @@
+cordova.define("org.apache.cordova.file.DirectoryEntry", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    utils = require('cordova/utils'),
+    exec = require('cordova/exec'),
+    Entry = require('./Entry'),
+    FileError = require('./FileError'),
+    DirectoryReader = require('./DirectoryReader');
+
+/**
+ * An interface representing a directory on the file system.
+ *
+ * {boolean} isFile always false (readonly)
+ * {boolean} isDirectory always true (readonly)
+ * {DOMString} name of the directory, excluding the path leading to it (readonly)
+ * {DOMString} fullPath the absolute full path to the directory (readonly)
+ * {FileSystem} filesystem on which the directory resides (readonly)
+ */
+var DirectoryEntry = function(name, fullPath, fileSystem, nativeURL) {
+
+    // add trailing slash if it is missing
+    if ((fullPath) && !/\/$/.test(fullPath)) {
+        fullPath += "/";
+    }
+    // add trailing slash if it is missing
+    if (nativeURL && !/\/$/.test(nativeURL)) {
+        nativeURL += "/";
+    }
+    DirectoryEntry.__super__.constructor.call(this, false, true, name, fullPath, fileSystem, nativeURL);
+};
+
+utils.extend(DirectoryEntry, Entry);
+
+/**
+ * Creates a new DirectoryReader to read entries from this directory
+ */
+DirectoryEntry.prototype.createReader = function() {
+    return new DirectoryReader(this.toInternalURL());
+};
+
+/**
+ * Creates or looks up a directory
+ *
+ * @param {DOMString} path either a relative or absolute path from this directory in which to look up or create a directory
+ * @param {Flags} options to create or exclusively create the directory
+ * @param {Function} successCallback is called with the new entry
+ * @param {Function} errorCallback is called with a FileError
+ */
+DirectoryEntry.prototype.getDirectory = function(path, options, successCallback, errorCallback) {
+    argscheck.checkArgs('sOFF', 'DirectoryEntry.getDirectory', arguments);
+    var fs = this.filesystem;
+    var win = successCallback && function(result) {
+        var entry = new DirectoryEntry(result.name, result.fullPath, fs, result.nativeURL);
+        successCallback(entry);
+    };
+    var fail = errorCallback && function(code) {
+        errorCallback(new FileError(code));
+    };
+    exec(win, fail, "File", "getDirectory", [this.toInternalURL(), path, options]);
+};
+
+/**
+ * Deletes a directory and all of it's contents
+ *
+ * @param {Function} successCallback is called with no parameters
+ * @param {Function} errorCallback is called with a FileError
+ */
+DirectoryEntry.prototype.removeRecursively = function(successCallback, errorCallback) {
+    argscheck.checkArgs('FF', 'DirectoryEntry.removeRecursively', arguments);
+    var fail = errorCallback && function(code) {
+        errorCallback(new FileError(code));
+    };
+    exec(successCallback, fail, "File", "removeRecursively", [this.toInternalURL()]);
+};
+
+/**
+ * Creates or looks up a file
+ *
+ * @param {DOMString} path either a relative or absolute path from this directory in which to look up or create a file
+ * @param {Flags} options to create or exclusively create the file
+ * @param {Function} successCallback is called with the new entry
+ * @param {Function} errorCallback is called with a FileError
+ */
+DirectoryEntry.prototype.getFile = function(path, options, successCallback, errorCallback) {
+    argscheck.checkArgs('sOFF', 'DirectoryEntry.getFile', arguments);
+    var fs = this.filesystem;
+    var win = successCallback && function(result) {
+        var FileEntry = require('./FileEntry');
+        var entry = new FileEntry(result.name, result.fullPath, fs, result.nativeURL);
+        successCallback(entry);
+    };
+    var fail = errorCallback && function(code) {
+        errorCallback(new FileError(code));
+    };
+    exec(win, fail, "File", "getFile", [this.toInternalURL(), path, options]);
+};
+
+module.exports = DirectoryEntry;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/DirectoryReader.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/DirectoryReader.js
@@ -1,0 +1,75 @@
+cordova.define("org.apache.cordova.file.DirectoryReader", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var exec = require('cordova/exec'),
+    FileError = require('./FileError') ;
+
+/**
+ * An interface that lists the files and directories in a directory.
+ */
+function DirectoryReader(localURL) {
+    this.localURL = localURL || null;
+    this.hasReadEntries = false;
+}
+
+/**
+ * Returns a list of entries from a directory.
+ *
+ * @param {Function} successCallback is called with a list of entries
+ * @param {Function} errorCallback is called with a FileError
+ */
+DirectoryReader.prototype.readEntries = function(successCallback, errorCallback) {
+    // If we've already read and passed on this directory's entries, return an empty list.
+    if (this.hasReadEntries) {
+        successCallback([]);
+        return;
+    }
+    var reader = this;
+    var win = typeof successCallback !== 'function' ? null : function(result) {
+        var retVal = [];
+        for (var i=0; i<result.length; i++) {
+            var entry = null;
+            if (result[i].isDirectory) {
+                entry = new (require('./DirectoryEntry'))();
+            }
+            else if (result[i].isFile) {
+                entry = new (require('./FileEntry'))();
+            }
+            entry.isDirectory = result[i].isDirectory;
+            entry.isFile = result[i].isFile;
+            entry.name = result[i].name;
+            entry.fullPath = result[i].fullPath;
+            entry.filesystem = new (require('./FileSystem'))(result[i].filesystemName);
+            entry.nativeURL = result[i].nativeURL;
+            retVal.push(entry);
+        }
+        reader.hasReadEntries = true;
+        successCallback(retVal);
+    };
+    var fail = typeof errorCallback !== 'function' ? null : function(code) {
+        errorCallback(new FileError(code));
+    };
+    exec(win, fail, "File", "readEntries", [this.localURL]);
+};
+
+module.exports = DirectoryReader;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/Entry.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/Entry.js
@@ -1,0 +1,262 @@
+cordova.define("org.apache.cordova.file.Entry", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    exec = require('cordova/exec'),
+    FileError = require('./FileError'),
+    Metadata = require('./Metadata');
+
+/**
+ * Represents a file or directory on the local file system.
+ *
+ * @param isFile
+ *            {boolean} true if Entry is a file (readonly)
+ * @param isDirectory
+ *            {boolean} true if Entry is a directory (readonly)
+ * @param name
+ *            {DOMString} name of the file or directory, excluding the path
+ *            leading to it (readonly)
+ * @param fullPath
+ *            {DOMString} the absolute full path to the file or directory
+ *            (readonly)
+ * @param fileSystem
+ *            {FileSystem} the filesystem on which this entry resides
+ *            (readonly)
+ * @param nativeURL
+ *            {DOMString} an alternate URL which can be used by native
+ *            webview controls, for example media players.
+ *            (optional, readonly)
+ */
+function Entry(isFile, isDirectory, name, fullPath, fileSystem, nativeURL) {
+    this.isFile = !!isFile;
+    this.isDirectory = !!isDirectory;
+    this.name = name || '';
+    this.fullPath = fullPath || '';
+    this.filesystem = fileSystem || null;
+    this.nativeURL = nativeURL || null;
+}
+
+/**
+ * Look up the metadata of the entry.
+ *
+ * @param successCallback
+ *            {Function} is called with a Metadata object
+ * @param errorCallback
+ *            {Function} is called with a FileError
+ */
+Entry.prototype.getMetadata = function(successCallback, errorCallback) {
+    argscheck.checkArgs('FF', 'Entry.getMetadata', arguments);
+    var success = successCallback && function(entryMetadata) {
+        var metadata = new Metadata({
+            size: entryMetadata.size,
+            modificationTime: entryMetadata.lastModifiedDate
+        });
+        successCallback(metadata);
+    };
+    var fail = errorCallback && function(code) {
+        errorCallback(new FileError(code));
+    };
+    exec(success, fail, "File", "getFileMetadata", [this.toInternalURL()]);
+};
+
+/**
+ * Set the metadata of the entry.
+ *
+ * @param successCallback
+ *            {Function} is called with a Metadata object
+ * @param errorCallback
+ *            {Function} is called with a FileError
+ * @param metadataObject
+ *            {Object} keys and values to set
+ */
+Entry.prototype.setMetadata = function(successCallback, errorCallback, metadataObject) {
+    argscheck.checkArgs('FFO', 'Entry.setMetadata', arguments);
+    exec(successCallback, errorCallback, "File", "setMetadata", [this.toInternalURL(), metadataObject]);
+};
+
+/**
+ * Move a file or directory to a new location.
+ *
+ * @param parent
+ *            {DirectoryEntry} the directory to which to move this entry
+ * @param newName
+ *            {DOMString} new name of the entry, defaults to the current name
+ * @param successCallback
+ *            {Function} called with the new DirectoryEntry object
+ * @param errorCallback
+ *            {Function} called with a FileError
+ */
+Entry.prototype.moveTo = function(parent, newName, successCallback, errorCallback) {
+    argscheck.checkArgs('oSFF', 'Entry.moveTo', arguments);
+    var fail = errorCallback && function(code) {
+        errorCallback(new FileError(code));
+    };
+    var filesystem = this.filesystem,
+        srcURL = this.toInternalURL(),
+        // entry name
+        name = newName || this.name,
+        success = function(entry) {
+            if (entry) {
+                if (successCallback) {
+                    // create appropriate Entry object
+                    var newFSName = entry.filesystemName || (entry.filesystem && entry.filesystem.name);
+                    var fs = newFSName ? new FileSystem(newFSName, { name: "", fullPath: "/" }) : new FileSystem(parent.filesystem.name, { name: "", fullPath: "/" });
+                    var result = (entry.isDirectory) ? new (require('./DirectoryEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL) : new (require('org.apache.cordova.file.FileEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL);
+                    successCallback(result);
+                }
+            }
+            else {
+                // no Entry object returned
+                fail && fail(FileError.NOT_FOUND_ERR);
+            }
+        };
+
+    // copy
+    exec(success, fail, "File", "moveTo", [srcURL, parent.toInternalURL(), name]);
+};
+
+/**
+ * Copy a directory to a different location.
+ *
+ * @param parent
+ *            {DirectoryEntry} the directory to which to copy the entry
+ * @param newName
+ *            {DOMString} new name of the entry, defaults to the current name
+ * @param successCallback
+ *            {Function} called with the new Entry object
+ * @param errorCallback
+ *            {Function} called with a FileError
+ */
+Entry.prototype.copyTo = function(parent, newName, successCallback, errorCallback) {
+    argscheck.checkArgs('oSFF', 'Entry.copyTo', arguments);
+    var fail = errorCallback && function(code) {
+        errorCallback(new FileError(code));
+    };
+    var filesystem = this.filesystem,
+        srcURL = this.toInternalURL(),
+        // entry name
+        name = newName || this.name,
+        // success callback
+        success = function(entry) {
+            if (entry) {
+                if (successCallback) {
+                    // create appropriate Entry object
+                    var newFSName = entry.filesystemName || (entry.filesystem && entry.filesystem.name);
+                    var fs = newFSName ? new FileSystem(newFSName, { name: "", fullPath: "/" }) : new FileSystem(parent.filesystem.name, { name: "", fullPath: "/" });
+                    var result = (entry.isDirectory) ? new (require('./DirectoryEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL) : new (require('org.apache.cordova.file.FileEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL);
+                    successCallback(result);
+                }
+            }
+            else {
+                // no Entry object returned
+                fail && fail(FileError.NOT_FOUND_ERR);
+            }
+        };
+
+    // copy
+    exec(success, fail, "File", "copyTo", [srcURL, parent.toInternalURL(), name]);
+};
+
+/**
+ * Return a URL that can be passed across the bridge to identify this entry.
+ */
+Entry.prototype.toInternalURL = function() {
+    if (this.filesystem && this.filesystem.__format__) {
+      return this.filesystem.__format__(this.fullPath);
+    }
+};
+
+/**
+ * Return a URL that can be used to identify this entry.
+ * Use a URL that can be used to as the src attribute of a <video> or
+ * <audio> tag. If that is not possible, construct a cdvfile:// URL.
+ */
+Entry.prototype.toURL = function() {
+    if (this.nativeURL) {
+      return this.nativeURL;
+    }
+    // fullPath attribute may contain the full URL in the case that
+    // toInternalURL fails.
+    return this.toInternalURL() || "file://localhost" + this.fullPath;
+};
+
+/**
+ * Backwards-compatibility: In v1.0.0 - 1.0.2, .toURL would only return a
+ * cdvfile:// URL, and this method was necessary to obtain URLs usable by the
+ * webview.
+ * See CB-6051, CB-6106, CB-6117, CB-6152, CB-6199, CB-6201, CB-6243, CB-6249,
+ * and CB-6300.
+ */
+Entry.prototype.toNativeURL = function() {
+    console.log("DEPRECATED: Update your code to use 'toURL'");
+    return this.toURL();
+};
+
+/**
+ * Returns a URI that can be used to identify this entry.
+ *
+ * @param {DOMString} mimeType for a FileEntry, the mime type to be used to interpret the file, when loaded through this URI.
+ * @return uri
+ */
+Entry.prototype.toURI = function(mimeType) {
+    console.log("DEPRECATED: Update your code to use 'toURL'");
+    return this.toURL();
+};
+
+/**
+ * Remove a file or directory. It is an error to attempt to delete a
+ * directory that is not empty. It is an error to attempt to delete a
+ * root directory of a file system.
+ *
+ * @param successCallback {Function} called with no parameters
+ * @param errorCallback {Function} called with a FileError
+ */
+Entry.prototype.remove = function(successCallback, errorCallback) {
+    argscheck.checkArgs('FF', 'Entry.remove', arguments);
+    var fail = errorCallback && function(code) {
+        errorCallback(new FileError(code));
+    };
+    exec(successCallback, fail, "File", "remove", [this.toInternalURL()]);
+};
+
+/**
+ * Look up the parent DirectoryEntry of this entry.
+ *
+ * @param successCallback {Function} called with the parent DirectoryEntry object
+ * @param errorCallback {Function} called with a FileError
+ */
+Entry.prototype.getParent = function(successCallback, errorCallback) {
+    argscheck.checkArgs('FF', 'Entry.getParent', arguments);
+    var fs = this.filesystem;
+    var win = successCallback && function(result) {
+        var DirectoryEntry = require('./DirectoryEntry');
+        var entry = new DirectoryEntry(result.name, result.fullPath, fs, result.nativeURL);
+        successCallback(entry);
+    };
+    var fail = errorCallback && function(code) {
+        errorCallback(new FileError(code));
+    };
+    exec(win, fail, "File", "getParent", [this.toInternalURL()]);
+};
+
+module.exports = Entry;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/File.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/File.js
@@ -1,0 +1,81 @@
+cordova.define("org.apache.cordova.file.File", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * Constructor.
+ * name {DOMString} name of the file, without path information
+ * fullPath {DOMString} the full path of the file, including the name
+ * type {DOMString} mime type
+ * lastModifiedDate {Date} last modified date
+ * size {Number} size of the file in bytes
+ */
+
+var File = function(name, localURL, type, lastModifiedDate, size){
+    this.name = name || '';
+    this.localURL = localURL || null;
+    this.type = type || null;
+    this.lastModified = lastModifiedDate || null;
+    // For backwards compatibility, store the timestamp in lastModifiedDate as well
+    this.lastModifiedDate = lastModifiedDate || null;
+    this.size = size || 0;
+
+    // These store the absolute start and end for slicing the file.
+    this.start = 0;
+    this.end = this.size;
+};
+
+/**
+ * Returns a "slice" of the file. Since Cordova Files don't contain the actual
+ * content, this really returns a File with adjusted start and end.
+ * Slices of slices are supported.
+ * start {Number} The index at which to start the slice (inclusive).
+ * end {Number} The index at which to end the slice (exclusive).
+ */
+File.prototype.slice = function(start, end) {
+    var size = this.end - this.start;
+    var newStart = 0;
+    var newEnd = size;
+    if (arguments.length) {
+        if (start < 0) {
+            newStart = Math.max(size + start, 0);
+        } else {
+            newStart = Math.min(size, start);
+        }
+    }
+
+    if (arguments.length >= 2) {
+        if (end < 0) {
+            newEnd = Math.max(size + end, 0);
+        } else {
+            newEnd = Math.min(end, size);
+        }
+    }
+
+    var newFile = new File(this.name, this.localURL, this.type, this.lastModified, this.size);
+    newFile.start = this.start + newStart;
+    newFile.end = this.start + newEnd;
+    return newFile;
+};
+
+
+module.exports = File;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/FileEntry.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/FileEntry.js
@@ -1,0 +1,83 @@
+cordova.define("org.apache.cordova.file.FileEntry", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var utils = require('cordova/utils'),
+    exec = require('cordova/exec'),
+    Entry = require('./Entry'),
+    FileWriter = require('./FileWriter'),
+    File = require('./File'),
+    FileError = require('./FileError');
+
+/**
+ * An interface representing a file on the file system.
+ *
+ * {boolean} isFile always true (readonly)
+ * {boolean} isDirectory always false (readonly)
+ * {DOMString} name of the file, excluding the path leading to it (readonly)
+ * {DOMString} fullPath the absolute full path to the file (readonly)
+ * {FileSystem} filesystem on which the file resides (readonly)
+ */
+var FileEntry = function(name, fullPath, fileSystem, nativeURL) {
+     FileEntry.__super__.constructor.apply(this, [true, false, name, fullPath, fileSystem, nativeURL]);
+};
+
+utils.extend(FileEntry, Entry);
+
+/**
+ * Creates a new FileWriter associated with the file that this FileEntry represents.
+ *
+ * @param {Function} successCallback is called with the new FileWriter
+ * @param {Function} errorCallback is called with a FileError
+ */
+FileEntry.prototype.createWriter = function(successCallback, errorCallback) {
+    this.file(function(filePointer) {
+        var writer = new FileWriter(filePointer);
+
+        if (writer.localURL === null || writer.localURL === "") {
+            errorCallback && errorCallback(new FileError(FileError.INVALID_STATE_ERR));
+        } else {
+            successCallback && successCallback(writer);
+        }
+    }, errorCallback);
+};
+
+/**
+ * Returns a File that represents the current state of the file that this FileEntry represents.
+ *
+ * @param {Function} successCallback is called with the new File object
+ * @param {Function} errorCallback is called with a FileError
+ */
+FileEntry.prototype.file = function(successCallback, errorCallback) {
+    var localURL = this.toInternalURL();
+    var win = successCallback && function(f) {
+        var file = new File(f.name, localURL, f.type, f.lastModifiedDate, f.size);
+        successCallback(file);
+    };
+    var fail = errorCallback && function(code) {
+        errorCallback(new FileError(code));
+    };
+    exec(win, fail, "File", "getFileMetadata", [localURL]);
+};
+
+
+module.exports = FileEntry;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/FileError.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/FileError.js
@@ -1,0 +1,48 @@
+cordova.define("org.apache.cordova.file.FileError", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * FileError
+ */
+function FileError(error) {
+  this.code = error || null;
+}
+
+// File error codes
+// Found in DOMException
+FileError.NOT_FOUND_ERR = 1;
+FileError.SECURITY_ERR = 2;
+FileError.ABORT_ERR = 3;
+
+// Added by File API specification
+FileError.NOT_READABLE_ERR = 4;
+FileError.ENCODING_ERR = 5;
+FileError.NO_MODIFICATION_ALLOWED_ERR = 6;
+FileError.INVALID_STATE_ERR = 7;
+FileError.SYNTAX_ERR = 8;
+FileError.INVALID_MODIFICATION_ERR = 9;
+FileError.QUOTA_EXCEEDED_ERR = 10;
+FileError.TYPE_MISMATCH_ERR = 11;
+FileError.PATH_EXISTS_ERR = 12;
+
+module.exports = FileError;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/FileReader.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/FileReader.js
@@ -1,0 +1,389 @@
+cordova.define("org.apache.cordova.file.FileReader", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var exec = require('cordova/exec'),
+    modulemapper = require('cordova/modulemapper'),
+    utils = require('cordova/utils'),
+    File = require('./File'),
+    FileError = require('./FileError'),
+    ProgressEvent = require('./ProgressEvent'),
+    origFileReader = modulemapper.getOriginalSymbol(window, 'FileReader');
+
+/**
+ * This class reads the mobile device file system.
+ *
+ * For Android:
+ *      The root directory is the root of the file system.
+ *      To read from the SD card, the file name is "sdcard/my_file.txt"
+ * @constructor
+ */
+var FileReader = function() {
+    this._readyState = 0;
+    this._error = null;
+    this._result = null;
+    this._localURL = '';
+    this._realReader = origFileReader ? new origFileReader() : {};
+};
+
+// States
+FileReader.EMPTY = 0;
+FileReader.LOADING = 1;
+FileReader.DONE = 2;
+
+utils.defineGetter(FileReader.prototype, 'readyState', function() {
+    return this._localURL ? this._readyState : this._realReader.readyState;
+});
+
+utils.defineGetter(FileReader.prototype, 'error', function() {
+    return this._localURL ? this._error: this._realReader.error;
+});
+
+utils.defineGetter(FileReader.prototype, 'result', function() {
+    return this._localURL ? this._result: this._realReader.result;
+});
+
+function defineEvent(eventName) {
+    utils.defineGetterSetter(FileReader.prototype, eventName, function() {
+        return this._realReader[eventName] || null;
+    }, function(value) {
+        this._realReader[eventName] = value;
+    });
+}
+defineEvent('onloadstart');    // When the read starts.
+defineEvent('onprogress');     // While reading (and decoding) file or fileBlob data, and reporting partial file data (progress.loaded/progress.total)
+defineEvent('onload');         // When the read has successfully completed.
+defineEvent('onerror');        // When the read has failed (see errors).
+defineEvent('onloadend');      // When the request has completed (either in success or failure).
+defineEvent('onabort');        // When the read has been aborted. For instance, by invoking the abort() method.
+
+function initRead(reader, file) {
+    // Already loading something
+    if (reader.readyState == FileReader.LOADING) {
+      throw new FileError(FileError.INVALID_STATE_ERR);
+    }
+
+    reader._result = null;
+    reader._error = null;
+    reader._readyState = FileReader.LOADING;
+
+    if (typeof file.localURL == 'string') {
+        reader._localURL = file.localURL;
+    } else {
+        reader._localURL = '';
+        return true;
+    }
+
+    reader.onloadstart && reader.onloadstart(new ProgressEvent("loadstart", {target:reader}));
+}
+
+/**
+ * Abort reading file.
+ */
+FileReader.prototype.abort = function() {
+    if (origFileReader && !this._localURL) {
+        return this._realReader.abort();
+    }
+    this._result = null;
+
+    if (this._readyState == FileReader.DONE || this._readyState == FileReader.EMPTY) {
+      return;
+    }
+
+    this._readyState = FileReader.DONE;
+
+    // If abort callback
+    if (typeof this.onabort === 'function') {
+        this.onabort(new ProgressEvent('abort', {target:this}));
+    }
+    // If load end callback
+    if (typeof this.onloadend === 'function') {
+        this.onloadend(new ProgressEvent('loadend', {target:this}));
+    }
+};
+
+/**
+ * Read text file.
+ *
+ * @param file          {File} File object containing file properties
+ * @param encoding      [Optional] (see http://www.iana.org/assignments/character-sets)
+ */
+FileReader.prototype.readAsText = function(file, encoding) {
+    if (initRead(this, file)) {
+        return this._realReader.readAsText(file, encoding);
+    }
+
+    // Default encoding is UTF-8
+    var enc = encoding ? encoding : "UTF-8";
+    var me = this;
+    var execArgs = [this._localURL, enc, file.start, file.end];
+
+    // Read file
+    exec(
+        // Success callback
+        function(r) {
+            // If DONE (cancelled), then don't do anything
+            if (me._readyState === FileReader.DONE) {
+                return;
+            }
+
+            // DONE state
+            me._readyState = FileReader.DONE;
+
+            // Save result
+            me._result = r;
+
+            // If onload callback
+            if (typeof me.onload === "function") {
+                me.onload(new ProgressEvent("load", {target:me}));
+            }
+
+            // If onloadend callback
+            if (typeof me.onloadend === "function") {
+                me.onloadend(new ProgressEvent("loadend", {target:me}));
+            }
+        },
+        // Error callback
+        function(e) {
+            // If DONE (cancelled), then don't do anything
+            if (me._readyState === FileReader.DONE) {
+                return;
+            }
+
+            // DONE state
+            me._readyState = FileReader.DONE;
+
+            // null result
+            me._result = null;
+
+            // Save error
+            me._error = new FileError(e);
+
+            // If onerror callback
+            if (typeof me.onerror === "function") {
+                me.onerror(new ProgressEvent("error", {target:me}));
+            }
+
+            // If onloadend callback
+            if (typeof me.onloadend === "function") {
+                me.onloadend(new ProgressEvent("loadend", {target:me}));
+            }
+        }, "File", "readAsText", execArgs);
+};
+
+
+/**
+ * Read file and return data as a base64 encoded data url.
+ * A data url is of the form:
+ *      data:[<mediatype>][;base64],<data>
+ *
+ * @param file          {File} File object containing file properties
+ */
+FileReader.prototype.readAsDataURL = function(file) {
+    if (initRead(this, file)) {
+        return this._realReader.readAsDataURL(file);
+    }
+
+    var me = this;
+    var execArgs = [this._localURL, file.start, file.end];
+
+    // Read file
+    exec(
+        // Success callback
+        function(r) {
+            // If DONE (cancelled), then don't do anything
+            if (me._readyState === FileReader.DONE) {
+                return;
+            }
+
+            // DONE state
+            me._readyState = FileReader.DONE;
+
+            // Save result
+            me._result = r;
+
+            // If onload callback
+            if (typeof me.onload === "function") {
+                me.onload(new ProgressEvent("load", {target:me}));
+            }
+
+            // If onloadend callback
+            if (typeof me.onloadend === "function") {
+                me.onloadend(new ProgressEvent("loadend", {target:me}));
+            }
+        },
+        // Error callback
+        function(e) {
+            // If DONE (cancelled), then don't do anything
+            if (me._readyState === FileReader.DONE) {
+                return;
+            }
+
+            // DONE state
+            me._readyState = FileReader.DONE;
+
+            me._result = null;
+
+            // Save error
+            me._error = new FileError(e);
+
+            // If onerror callback
+            if (typeof me.onerror === "function") {
+                me.onerror(new ProgressEvent("error", {target:me}));
+            }
+
+            // If onloadend callback
+            if (typeof me.onloadend === "function") {
+                me.onloadend(new ProgressEvent("loadend", {target:me}));
+            }
+        }, "File", "readAsDataURL", execArgs);
+};
+
+/**
+ * Read file and return data as a binary data.
+ *
+ * @param file          {File} File object containing file properties
+ */
+FileReader.prototype.readAsBinaryString = function(file) {
+    if (initRead(this, file)) {
+        return this._realReader.readAsBinaryString(file);
+    }
+
+    var me = this;
+    var execArgs = [this._localURL, file.start, file.end];
+
+    // Read file
+    exec(
+        // Success callback
+        function(r) {
+            // If DONE (cancelled), then don't do anything
+            if (me._readyState === FileReader.DONE) {
+                return;
+            }
+
+            // DONE state
+            me._readyState = FileReader.DONE;
+
+            me._result = r;
+
+            // If onload callback
+            if (typeof me.onload === "function") {
+                me.onload(new ProgressEvent("load", {target:me}));
+            }
+
+            // If onloadend callback
+            if (typeof me.onloadend === "function") {
+                me.onloadend(new ProgressEvent("loadend", {target:me}));
+            }
+        },
+        // Error callback
+        function(e) {
+            // If DONE (cancelled), then don't do anything
+            if (me._readyState === FileReader.DONE) {
+                return;
+            }
+
+            // DONE state
+            me._readyState = FileReader.DONE;
+
+            me._result = null;
+
+            // Save error
+            me._error = new FileError(e);
+
+            // If onerror callback
+            if (typeof me.onerror === "function") {
+                me.onerror(new ProgressEvent("error", {target:me}));
+            }
+
+            // If onloadend callback
+            if (typeof me.onloadend === "function") {
+                me.onloadend(new ProgressEvent("loadend", {target:me}));
+            }
+        }, "File", "readAsBinaryString", execArgs);
+};
+
+/**
+ * Read file and return data as a binary data.
+ *
+ * @param file          {File} File object containing file properties
+ */
+FileReader.prototype.readAsArrayBuffer = function(file) {
+    if (initRead(this, file)) {
+        return this._realReader.readAsArrayBuffer(file);
+    }
+
+    var me = this;
+    var execArgs = [this._localURL, file.start, file.end];
+
+    // Read file
+    exec(
+        // Success callback
+        function(r) {
+            // If DONE (cancelled), then don't do anything
+            if (me._readyState === FileReader.DONE) {
+                return;
+            }
+
+            // DONE state
+            me._readyState = FileReader.DONE;
+
+            me._result = r;
+
+            // If onload callback
+            if (typeof me.onload === "function") {
+                me.onload(new ProgressEvent("load", {target:me}));
+            }
+
+            // If onloadend callback
+            if (typeof me.onloadend === "function") {
+                me.onloadend(new ProgressEvent("loadend", {target:me}));
+            }
+        },
+        // Error callback
+        function(e) {
+            // If DONE (cancelled), then don't do anything
+            if (me._readyState === FileReader.DONE) {
+                return;
+            }
+
+            // DONE state
+            me._readyState = FileReader.DONE;
+
+            me._result = null;
+
+            // Save error
+            me._error = new FileError(e);
+
+            // If onerror callback
+            if (typeof me.onerror === "function") {
+                me.onerror(new ProgressEvent("error", {target:me}));
+            }
+
+            // If onloadend callback
+            if (typeof me.onloadend === "function") {
+                me.onloadend(new ProgressEvent("loadend", {target:me}));
+            }
+        }, "File", "readAsArrayBuffer", execArgs);
+};
+
+module.exports = FileReader;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/FileSystem.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/FileSystem.js
@@ -1,0 +1,50 @@
+cordova.define("org.apache.cordova.file.FileSystem", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var DirectoryEntry = require('./DirectoryEntry');
+
+/**
+ * An interface representing a file system
+ *
+ * @constructor
+ * {DOMString} name the unique name of the file system (readonly)
+ * {DirectoryEntry} root directory of the file system (readonly)
+ */
+var FileSystem = function(name, root) {
+    this.name = name;
+    if (root) {
+        this.root = new DirectoryEntry(root.name, root.fullPath, this, root.nativeURL);
+    } else {
+        this.root = new DirectoryEntry(this.name, '/', this);
+    }
+};
+
+FileSystem.prototype.__format__ = function(fullPath) {
+    return fullPath;
+};
+
+FileSystem.prototype.toJSON = function() {
+    return "<FileSystem: " + this.name + ">";
+};
+
+module.exports = FileSystem;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/FileUploadOptions.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/FileUploadOptions.js
@@ -1,0 +1,43 @@
+cordova.define("org.apache.cordova.file.FileUploadOptions", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * Options to customize the HTTP request used to upload files.
+ * @constructor
+ * @param fileKey {String}   Name of file request parameter.
+ * @param fileName {String}  Filename to be used by the server. Defaults to image.jpg.
+ * @param mimeType {String}  Mimetype of the uploaded file. Defaults to image/jpeg.
+ * @param params {Object}    Object with key: value params to send to the server.
+ * @param headers {Object}   Keys are header names, values are header values. Multiple
+ *                           headers of the same name are not supported.
+ */
+var FileUploadOptions = function(fileKey, fileName, mimeType, params, headers, httpMethod) {
+    this.fileKey = fileKey || null;
+    this.fileName = fileName || null;
+    this.mimeType = mimeType || null;
+    this.params = params || null;
+    this.headers = headers || null;
+    this.httpMethod = httpMethod || null;
+};
+
+module.exports = FileUploadOptions;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/FileUploadResult.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/FileUploadResult.js
@@ -1,0 +1,31 @@
+cordova.define("org.apache.cordova.file.FileUploadResult", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * FileUploadResult
+ * @constructor
+ */
+module.exports = function FileUploadResult(size, code, content) {
+	this.bytesSent = size;
+	this.responseCode = code;
+	this.response = content;
+ };
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/FileWriter.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/FileWriter.js
@@ -1,0 +1,303 @@
+cordova.define("org.apache.cordova.file.FileWriter", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var exec = require('cordova/exec'),
+    FileError = require('./FileError'),
+    ProgressEvent = require('./ProgressEvent');
+
+/**
+ * This class writes to the mobile device file system.
+ *
+ * For Android:
+ *      The root directory is the root of the file system.
+ *      To write to the SD card, the file name is "sdcard/my_file.txt"
+ *
+ * @constructor
+ * @param file {File} File object containing file properties
+ * @param append if true write to the end of the file, otherwise overwrite the file
+ */
+var FileWriter = function(file) {
+    this.fileName = "";
+    this.length = 0;
+    if (file) {
+        this.localURL = file.localURL || file;
+        this.length = file.size || 0;
+    }
+    // default is to write at the beginning of the file
+    this.position = 0;
+
+    this.readyState = 0; // EMPTY
+
+    this.result = null;
+
+    // Error
+    this.error = null;
+
+    // Event handlers
+    this.onwritestart = null;   // When writing starts
+    this.onprogress = null;     // While writing the file, and reporting partial file data
+    this.onwrite = null;        // When the write has successfully completed.
+    this.onwriteend = null;     // When the request has completed (either in success or failure).
+    this.onabort = null;        // When the write has been aborted. For instance, by invoking the abort() method.
+    this.onerror = null;        // When the write has failed (see errors).
+};
+
+// States
+FileWriter.INIT = 0;
+FileWriter.WRITING = 1;
+FileWriter.DONE = 2;
+
+/**
+ * Abort writing file.
+ */
+FileWriter.prototype.abort = function() {
+    // check for invalid state
+    if (this.readyState === FileWriter.DONE || this.readyState === FileWriter.INIT) {
+        throw new FileError(FileError.INVALID_STATE_ERR);
+    }
+
+    // set error
+    this.error = new FileError(FileError.ABORT_ERR);
+
+    this.readyState = FileWriter.DONE;
+
+    // If abort callback
+    if (typeof this.onabort === "function") {
+        this.onabort(new ProgressEvent("abort", {"target":this}));
+    }
+
+    // If write end callback
+    if (typeof this.onwriteend === "function") {
+        this.onwriteend(new ProgressEvent("writeend", {"target":this}));
+    }
+};
+
+/**
+ * Writes data to the file
+ *
+ * @param data text or blob to be written
+ */
+FileWriter.prototype.write = function(data) {
+
+    var that=this;
+    var supportsBinary = (typeof window.Blob !== 'undefined' && typeof window.ArrayBuffer !== 'undefined');
+    var isBinary;
+
+    // Check to see if the incoming data is a blob
+    if (data instanceof File || (supportsBinary && data instanceof Blob)) {
+        var fileReader = new FileReader();
+        fileReader.onload = function() {
+            // Call this method again, with the arraybuffer as argument
+            FileWriter.prototype.write.call(that, this.result);
+        };
+        if (supportsBinary) {
+            fileReader.readAsArrayBuffer(data);
+        } else {
+            fileReader.readAsText(data);
+        }
+        return;
+    }
+
+    // Mark data type for safer transport over the binary bridge
+    isBinary = supportsBinary && (data instanceof ArrayBuffer);
+    if (isBinary && ['windowsphone', 'windows8'].indexOf(cordova.platformId) >= 0) {
+        // create a plain array, using the keys from the Uint8Array view so that we can serialize it
+        data = Array.apply(null, new Uint8Array(data));
+    }
+    
+    // Throw an exception if we are already writing a file
+    if (this.readyState === FileWriter.WRITING) {
+        throw new FileError(FileError.INVALID_STATE_ERR);
+    }
+
+    // WRITING state
+    this.readyState = FileWriter.WRITING;
+
+    var me = this;
+
+    // If onwritestart callback
+    if (typeof me.onwritestart === "function") {
+        me.onwritestart(new ProgressEvent("writestart", {"target":me}));
+    }
+
+    // Write file
+    exec(
+        // Success callback
+        function(r) {
+            // If DONE (cancelled), then don't do anything
+            if (me.readyState === FileWriter.DONE) {
+                return;
+            }
+
+            // position always increases by bytes written because file would be extended
+            me.position += r;
+            // The length of the file is now where we are done writing.
+
+            me.length = me.position;
+
+            // DONE state
+            me.readyState = FileWriter.DONE;
+
+            // If onwrite callback
+            if (typeof me.onwrite === "function") {
+                me.onwrite(new ProgressEvent("write", {"target":me}));
+            }
+
+            // If onwriteend callback
+            if (typeof me.onwriteend === "function") {
+                me.onwriteend(new ProgressEvent("writeend", {"target":me}));
+            }
+        },
+        // Error callback
+        function(e) {
+            // If DONE (cancelled), then don't do anything
+            if (me.readyState === FileWriter.DONE) {
+                return;
+            }
+
+            // DONE state
+            me.readyState = FileWriter.DONE;
+
+            // Save error
+            me.error = new FileError(e);
+
+            // If onerror callback
+            if (typeof me.onerror === "function") {
+                me.onerror(new ProgressEvent("error", {"target":me}));
+            }
+
+            // If onwriteend callback
+            if (typeof me.onwriteend === "function") {
+                me.onwriteend(new ProgressEvent("writeend", {"target":me}));
+            }
+        }, "File", "write", [this.localURL, data, this.position, isBinary]);
+};
+
+/**
+ * Moves the file pointer to the location specified.
+ *
+ * If the offset is a negative number the position of the file
+ * pointer is rewound.  If the offset is greater than the file
+ * size the position is set to the end of the file.
+ *
+ * @param offset is the location to move the file pointer to.
+ */
+FileWriter.prototype.seek = function(offset) {
+    // Throw an exception if we are already writing a file
+    if (this.readyState === FileWriter.WRITING) {
+        throw new FileError(FileError.INVALID_STATE_ERR);
+    }
+
+    if (!offset && offset !== 0) {
+        return;
+    }
+
+    // See back from end of file.
+    if (offset < 0) {
+        this.position = Math.max(offset + this.length, 0);
+    }
+    // Offset is bigger than file size so set position
+    // to the end of the file.
+    else if (offset > this.length) {
+        this.position = this.length;
+    }
+    // Offset is between 0 and file size so set the position
+    // to start writing.
+    else {
+        this.position = offset;
+    }
+};
+
+/**
+ * Truncates the file to the size specified.
+ *
+ * @param size to chop the file at.
+ */
+FileWriter.prototype.truncate = function(size) {
+    // Throw an exception if we are already writing a file
+    if (this.readyState === FileWriter.WRITING) {
+        throw new FileError(FileError.INVALID_STATE_ERR);
+    }
+
+    // WRITING state
+    this.readyState = FileWriter.WRITING;
+
+    var me = this;
+
+    // If onwritestart callback
+    if (typeof me.onwritestart === "function") {
+        me.onwritestart(new ProgressEvent("writestart", {"target":this}));
+    }
+
+    // Write file
+    exec(
+        // Success callback
+        function(r) {
+            // If DONE (cancelled), then don't do anything
+            if (me.readyState === FileWriter.DONE) {
+                return;
+            }
+
+            // DONE state
+            me.readyState = FileWriter.DONE;
+
+            // Update the length of the file
+            me.length = r;
+            me.position = Math.min(me.position, r);
+
+            // If onwrite callback
+            if (typeof me.onwrite === "function") {
+                me.onwrite(new ProgressEvent("write", {"target":me}));
+            }
+
+            // If onwriteend callback
+            if (typeof me.onwriteend === "function") {
+                me.onwriteend(new ProgressEvent("writeend", {"target":me}));
+            }
+        },
+        // Error callback
+        function(e) {
+            // If DONE (cancelled), then don't do anything
+            if (me.readyState === FileWriter.DONE) {
+                return;
+            }
+
+            // DONE state
+            me.readyState = FileWriter.DONE;
+
+            // Save error
+            me.error = new FileError(e);
+
+            // If onerror callback
+            if (typeof me.onerror === "function") {
+                me.onerror(new ProgressEvent("error", {"target":me}));
+            }
+
+            // If onwriteend callback
+            if (typeof me.onwriteend === "function") {
+                me.onwriteend(new ProgressEvent("writeend", {"target":me}));
+            }
+        }, "File", "truncate", [this.localURL, size]);
+};
+
+module.exports = FileWriter;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/Flags.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/Flags.js
@@ -1,0 +1,38 @@
+cordova.define("org.apache.cordova.file.Flags", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * Supplies arguments to methods that lookup or create files and directories.
+ *
+ * @param create
+ *            {boolean} file or directory if it doesn't exist
+ * @param exclusive
+ *            {boolean} used with create; if true the command will fail if
+ *            target path exists
+ */
+function Flags(create, exclusive) {
+    this.create = create || false;
+    this.exclusive = exclusive || false;
+}
+
+module.exports = Flags;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/LocalFileSystem.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/LocalFileSystem.js
@@ -1,0 +1,25 @@
+cordova.define("org.apache.cordova.file.LocalFileSystem", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+exports.TEMPORARY = 0;
+exports.PERSISTENT = 1;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/Metadata.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/Metadata.js
@@ -1,0 +1,42 @@
+cordova.define("org.apache.cordova.file.Metadata", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * Information about the state of the file or directory
+ *
+ * {Date} modificationTime (readonly)
+ */
+var Metadata = function(metadata) {
+    if (typeof metadata == "object") {
+        this.modificationTime = new Date(metadata.modificationTime);
+        this.size = metadata.size || 0;
+    } else if (typeof metadata == "undefined") {
+        this.modificationTime = null;
+        this.size = 0;
+    } else {
+        /* Backwards compatiblity with platforms that only return a timestamp */
+        this.modificationTime = new Date(metadata);
+    }
+};
+
+module.exports = Metadata;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/ProgressEvent.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/ProgressEvent.js
@@ -1,0 +1,69 @@
+cordova.define("org.apache.cordova.file.ProgressEvent", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+// If ProgressEvent exists in global context, use it already, otherwise use our own polyfill
+// Feature test: See if we can instantiate a native ProgressEvent;
+// if so, use that approach,
+// otherwise fill-in with our own implementation.
+//
+// NOTE: right now we always fill in with our own. Down the road would be nice if we can use whatever is native in the webview.
+var ProgressEvent = (function() {
+    /*
+    var createEvent = function(data) {
+        var event = document.createEvent('Events');
+        event.initEvent('ProgressEvent', false, false);
+        if (data) {
+            for (var i in data) {
+                if (data.hasOwnProperty(i)) {
+                    event[i] = data[i];
+                }
+            }
+            if (data.target) {
+                // TODO: cannot call <some_custom_object>.dispatchEvent
+                // need to first figure out how to implement EventTarget
+            }
+        }
+        return event;
+    };
+    try {
+        var ev = createEvent({type:"abort",target:document});
+        return function ProgressEvent(type, data) {
+            data.type = type;
+            return createEvent(data);
+        };
+    } catch(e){
+    */
+        return function ProgressEvent(type, dict) {
+            this.type = type;
+            this.bubbles = false;
+            this.cancelBubble = false;
+            this.cancelable = false;
+            this.lengthComputable = false;
+            this.loaded = dict && dict.loaded ? dict.loaded : 0;
+            this.total = dict && dict.total ? dict.total : 0;
+            this.target = dict && dict.target ? dict.target : null;
+        };
+    //}
+})();
+
+module.exports = ProgressEvent;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/fileSystemPaths.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/fileSystemPaths.js
@@ -1,0 +1,65 @@
+cordova.define("org.apache.cordova.file.fileSystemPaths", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var exec = require('cordova/exec');
+var channel = require('cordova/channel');
+
+exports.file = {
+    // Read-only directory where the application is installed.
+    applicationDirectory: null,
+    // Root of app's private writable storage
+    applicationStorageDirectory: null,
+    // Where to put app-specific data files.
+    dataDirectory: null,
+    // Cached files that should survive app restarts.
+    // Apps should not rely on the OS to delete files in here.
+    cacheDirectory: null,
+    // Android: the application space on external storage.
+    externalApplicationStorageDirectory: null,
+    // Android: Where to put app-specific data files on external storage.
+    externalDataDirectory: null,
+    // Android: the application cache on external storage.
+    externalCacheDirectory: null,
+    // Android: the external storage (SD card) root.
+    externalRootDirectory: null,
+    // iOS: Temp directory that the OS can clear at will.
+    tempDirectory: null,
+    // iOS: Holds app-specific files that should be synced (e.g. to iCloud).
+    syncedDataDirectory: null,
+    // iOS: Files private to the app, but that are meaningful to other applciations (e.g. Office files)
+    documentsDirectory: null,
+    // BlackBerry10: Files globally available to all apps
+    sharedDirectory: null
+};
+
+channel.waitForInitialization('onFileSystemPathsReady');
+channel.onCordovaReady.subscribe(function() {
+    function after(paths) {
+        for (var k in paths) {
+            exports.file[k] = paths[k];
+        }
+        channel.initializationComplete('onFileSystemPathsReady');
+    }
+    exec(after, null, 'File', 'requestAllPaths', []);
+});
+
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/fileSystems.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/fileSystems.js
@@ -1,0 +1,27 @@
+cordova.define("org.apache.cordova.file.fileSystems", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+// Overridden by Android, BlackBerry 10 and iOS to populate fsMap.
+module.exports.getFs = function(name, callback) {
+    callback(null);
+};
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/firefoxos/FileSystem.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/firefoxos/FileSystem.js
@@ -1,0 +1,31 @@
+cordova.define("org.apache.cordova.file.firefoxFileSystem", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+FILESYSTEM_PREFIX = "cdvfile://";
+
+module.exports = {
+    __format__: function(fullPath) {
+        return (FILESYSTEM_PREFIX + this.name + (fullPath[0] === '/' ? '' : '/') + encodeURI(fullPath));
+    }
+};
+
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/requestFileSystem.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/requestFileSystem.js
@@ -1,0 +1,67 @@
+cordova.define("org.apache.cordova.file.requestFileSystem", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    FileError = require('./FileError'),
+    FileSystem = require('./FileSystem'),
+    exec = require('cordova/exec');
+var fileSystems = require('./fileSystems');
+
+/**
+ * Request a file system in which to store application data.
+ * @param type  local file system type
+ * @param size  indicates how much storage space, in bytes, the application expects to need
+ * @param successCallback  invoked with a FileSystem object
+ * @param errorCallback  invoked if error occurs retrieving file system
+ */
+var requestFileSystem = function(type, size, successCallback, errorCallback) {
+    argscheck.checkArgs('nnFF', 'requestFileSystem', arguments);
+    var fail = function(code) {
+        errorCallback && errorCallback(new FileError(code));
+    };
+
+    if (type < 0) {
+        fail(FileError.SYNTAX_ERR);
+    } else {
+        // if successful, return a FileSystem object
+        var success = function(file_system) {
+            if (file_system) {
+                if (successCallback) {
+                    fileSystems.getFs(file_system.name, function(fs) {
+                        if (!fs) {
+                            fs = new FileSystem(file_system.name, file_system.root);
+                        }
+                        successCallback(fs);
+                    });
+                }
+            }
+            else {
+                // no FileSystem object returned
+                fail(FileError.NOT_FOUND_ERR);
+            }
+        };
+        exec(success, fail, "File", "requestFileSystem", [type, size]);
+    }
+};
+
+module.exports = requestFileSystem;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/resolveLocalFileSystemURI.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.file/www/resolveLocalFileSystemURI.js
@@ -1,0 +1,77 @@
+cordova.define("org.apache.cordova.file.resolveLocalFileSystemURI", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    DirectoryEntry = require('./DirectoryEntry'),
+    FileEntry = require('./FileEntry'),
+    FileError = require('./FileError'),
+    exec = require('cordova/exec');
+var fileSystems = require('./fileSystems');
+
+/**
+ * Look up file system Entry referred to by local URI.
+ * @param {DOMString} uri  URI referring to a local file or directory
+ * @param successCallback  invoked with Entry object corresponding to URI
+ * @param errorCallback    invoked if error occurs retrieving file system entry
+ */
+module.exports.resolveLocalFileSystemURL = function(uri, successCallback, errorCallback) {
+    argscheck.checkArgs('sFF', 'resolveLocalFileSystemURI', arguments);
+    // error callback
+    var fail = function(error) {
+        errorCallback && errorCallback(new FileError(error));
+    };
+    // sanity check for 'not:valid:filename' or '/not:valid:filename'
+    // file.spec.12 window.resolveLocalFileSystemURI should error (ENCODING_ERR) when resolving invalid URI with leading /.
+    if(!uri || uri.split(":").length > 2) {
+        setTimeout( function() {
+            fail(FileError.ENCODING_ERR);
+        },0);
+        return;
+    }
+    // if successful, return either a file or directory entry
+    var success = function(entry) {
+        if (entry) {
+            if (successCallback) {
+                // create appropriate Entry object
+                var fsName = entry.filesystemName || (entry.filesystem && entry.filesystem.name) || (entry.filesystem == window.PERSISTENT ? 'persistent' : 'temporary');
+                fileSystems.getFs(fsName, function(fs) {
+                    if (!fs) {
+                        fs = new FileSystem(fsName, {name:"", fullPath:"/"});
+                    }
+                    var result = (entry.isDirectory) ? new DirectoryEntry(entry.name, entry.fullPath, fs, entry.nativeURL) : new FileEntry(entry.name, entry.fullPath, fs, entry.nativeURL);
+                    successCallback(result);
+                });
+            }
+        }
+        else {
+            // no Entry object returned
+            fail(FileError.NOT_FOUND_ERR);
+        }
+    };
+
+    exec(success, fail, "File", "resolveLocalFileSystemURI", [uri]);
+};
+module.exports.resolveLocalFileSystemURI = function() {
+    console.log("resolveLocalFileSystemURI is deprecated. Please call resolveLocalFileSystemURL instead.");
+    module.exports.resolveLocalFileSystemURL.apply(this, arguments);
+};
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.geolocation/src/firefoxos/GeolocationProxy.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.geolocation/src/firefoxos/GeolocationProxy.js
@@ -1,0 +1,66 @@
+cordova.define("org.apache.cordova.geolocation.GeolocationProxy", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+           
+// latest geolocation spec can be found here: http://www.w3.org/TR/geolocation-API/
+
+var idsMap = {};
+
+module.exports = {
+    getLocation: function(success, error, args) {
+        var geo = cordova.require('cordova/modulemapper').getOriginalSymbol(window, 'navigator.geolocation');
+        function successCallback(position) {
+          // Cordova is creating Position object using just coords
+          success(position.coords);
+        }
+        geo.getCurrentPosition(successCallback, error, {
+            enableHighAccuracy: args[0],
+            maximumAge: args[1]
+        });
+    },
+
+    addWatch: function(success, error, args) {
+        var geo = cordova.require('cordova/modulemapper').getOriginalSymbol(window, 'navigator.geolocation');        
+        var id = args[0];
+        var nativeId = geo.watchPosition(success, error, {
+            enableHighAccuracy: args[1]
+        });
+
+        idsMap[id] = nativeId;
+    },
+
+    clearWatch: function(success, error, args) {
+        var geo = cordova.require('cordova/modulemapper').getOriginalSymbol(window, 'navigator.geolocation');
+        var id = args[0];
+
+        if(id in idsMap) {
+            geo.clearWatch(idsMap[id]);
+            delete idsMap[id];
+        }
+
+        if(success) {
+            success();
+        }
+    }
+};
+
+require("cordova/exec/proxy").add("Geolocation", module.exports);
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.geolocation/www/Coordinates.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.geolocation/www/Coordinates.js
@@ -1,0 +1,71 @@
+cordova.define("org.apache.cordova.geolocation.Coordinates", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * This class contains position information.
+ * @param {Object} lat
+ * @param {Object} lng
+ * @param {Object} alt
+ * @param {Object} acc
+ * @param {Object} head
+ * @param {Object} vel
+ * @param {Object} altacc
+ * @constructor
+ */
+var Coordinates = function(lat, lng, alt, acc, head, vel, altacc) {
+    /**
+     * The latitude of the position.
+     */
+    this.latitude = lat;
+    /**
+     * The longitude of the position,
+     */
+    this.longitude = lng;
+    /**
+     * The accuracy of the position.
+     */
+    this.accuracy = acc;
+    /**
+     * The altitude of the position.
+     */
+    this.altitude = (alt !== undefined ? alt : null);
+    /**
+     * The direction the device is moving at the position.
+     */
+    this.heading = (head !== undefined ? head : null);
+    /**
+     * The velocity with which the device is moving at the position.
+     */
+    this.speed = (vel !== undefined ? vel : null);
+
+    if (this.speed === 0 || this.speed === null) {
+        this.heading = NaN;
+    }
+
+    /**
+     * The altitude accuracy of the position.
+     */
+    this.altitudeAccuracy = (altacc !== undefined) ? altacc : null;
+};
+
+module.exports = Coordinates;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.geolocation/www/Position.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.geolocation/www/Position.js
@@ -1,0 +1,35 @@
+cordova.define("org.apache.cordova.geolocation.Position", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var Coordinates = require('./Coordinates');
+
+var Position = function(coords, timestamp) {
+    if (coords) {
+        this.coords = new Coordinates(coords.latitude, coords.longitude, coords.altitude, coords.accuracy, coords.heading, coords.velocity, coords.altitudeAccuracy);
+    } else {
+        this.coords = new Coordinates();
+    }
+    this.timestamp = (timestamp !== undefined) ? timestamp : new Date();
+};
+
+module.exports = Position;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.geolocation/www/PositionError.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.geolocation/www/PositionError.js
@@ -1,0 +1,40 @@
+cordova.define("org.apache.cordova.geolocation.PositionError", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * Position error object
+ *
+ * @constructor
+ * @param code
+ * @param message
+ */
+var PositionError = function(code, message) {
+    this.code = code || null;
+    this.message = message || '';
+};
+
+PositionError.PERMISSION_DENIED = 1;
+PositionError.POSITION_UNAVAILABLE = 2;
+PositionError.TIMEOUT = 3;
+
+module.exports = PositionError;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.geolocation/www/geolocation.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.geolocation/www/geolocation.js
@@ -1,0 +1,213 @@
+cordova.define("org.apache.cordova.geolocation.geolocation", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    utils = require('cordova/utils'),
+    exec = require('cordova/exec'),
+    PositionError = require('./PositionError'),
+    Position = require('./Position');
+
+var timers = {};   // list of timers in use
+
+// Returns default params, overrides if provided with values
+function parseParameters(options) {
+    var opt = {
+        maximumAge: 0,
+        enableHighAccuracy: false,
+        timeout: Infinity
+    };
+
+    if (options) {
+        if (options.maximumAge !== undefined && !isNaN(options.maximumAge) && options.maximumAge > 0) {
+            opt.maximumAge = options.maximumAge;
+        }
+        if (options.enableHighAccuracy !== undefined) {
+            opt.enableHighAccuracy = options.enableHighAccuracy;
+        }
+        if (options.timeout !== undefined && !isNaN(options.timeout)) {
+            if (options.timeout < 0) {
+                opt.timeout = 0;
+            } else {
+                opt.timeout = options.timeout;
+            }
+        }
+    }
+
+    return opt;
+}
+
+// Returns a timeout failure, closed over a specified timeout value and error callback.
+function createTimeout(errorCallback, timeout) {
+    var t = setTimeout(function() {
+        clearTimeout(t);
+        t = null;
+        errorCallback({
+            code:PositionError.TIMEOUT,
+            message:"Position retrieval timed out."
+        });
+    }, timeout);
+    return t;
+}
+
+var geolocation = {
+    lastPosition:null, // reference to last known (cached) position returned
+    /**
+   * Asynchronously acquires the current position.
+   *
+   * @param {Function} successCallback    The function to call when the position data is available
+   * @param {Function} errorCallback      The function to call when there is an error getting the heading position. (OPTIONAL)
+   * @param {PositionOptions} options     The options for getting the position data. (OPTIONAL)
+   */
+    getCurrentPosition:function(successCallback, errorCallback, options) {
+        argscheck.checkArgs('fFO', 'geolocation.getCurrentPosition', arguments);
+        options = parseParameters(options);
+
+        // Timer var that will fire an error callback if no position is retrieved from native
+        // before the "timeout" param provided expires
+        var timeoutTimer = {timer:null};
+
+        var win = function(p) {
+            clearTimeout(timeoutTimer.timer);
+            if (!(timeoutTimer.timer)) {
+                // Timeout already happened, or native fired error callback for
+                // this geo request.
+                // Don't continue with success callback.
+                return;
+            }
+            var pos = new Position(
+                {
+                    latitude:p.latitude,
+                    longitude:p.longitude,
+                    altitude:p.altitude,
+                    accuracy:p.accuracy,
+                    heading:p.heading,
+                    velocity:p.velocity,
+                    altitudeAccuracy:p.altitudeAccuracy
+                },
+                (p.timestamp === undefined ? new Date() : ((p.timestamp instanceof Date) ? p.timestamp : new Date(p.timestamp)))
+            );
+            geolocation.lastPosition = pos;
+            successCallback(pos);
+        };
+        var fail = function(e) {
+            clearTimeout(timeoutTimer.timer);
+            timeoutTimer.timer = null;
+            var err = new PositionError(e.code, e.message);
+            if (errorCallback) {
+                errorCallback(err);
+            }
+        };
+
+        // Check our cached position, if its timestamp difference with current time is less than the maximumAge, then just
+        // fire the success callback with the cached position.
+        if (geolocation.lastPosition && options.maximumAge && (((new Date()).getTime() - geolocation.lastPosition.timestamp.getTime()) <= options.maximumAge)) {
+            successCallback(geolocation.lastPosition);
+        // If the cached position check failed and the timeout was set to 0, error out with a TIMEOUT error object.
+        } else if (options.timeout === 0) {
+            fail({
+                code:PositionError.TIMEOUT,
+                message:"timeout value in PositionOptions set to 0 and no cached Position object available, or cached Position object's age exceeds provided PositionOptions' maximumAge parameter."
+            });
+        // Otherwise we have to call into native to retrieve a position.
+        } else {
+            if (options.timeout !== Infinity) {
+                // If the timeout value was not set to Infinity (default), then
+                // set up a timeout function that will fire the error callback
+                // if no successful position was retrieved before timeout expired.
+                timeoutTimer.timer = createTimeout(fail, options.timeout);
+            } else {
+                // This is here so the check in the win function doesn't mess stuff up
+                // may seem weird but this guarantees timeoutTimer is
+                // always truthy before we call into native
+                timeoutTimer.timer = true;
+            }
+            exec(win, fail, "Geolocation", "getLocation", [options.enableHighAccuracy, options.maximumAge]);
+        }
+        return timeoutTimer;
+    },
+    /**
+     * Asynchronously watches the geolocation for changes to geolocation.  When a change occurs,
+     * the successCallback is called with the new location.
+     *
+     * @param {Function} successCallback    The function to call each time the location data is available
+     * @param {Function} errorCallback      The function to call when there is an error getting the location data. (OPTIONAL)
+     * @param {PositionOptions} options     The options for getting the location data such as frequency. (OPTIONAL)
+     * @return String                       The watch id that must be passed to #clearWatch to stop watching.
+     */
+    watchPosition:function(successCallback, errorCallback, options) {
+        argscheck.checkArgs('fFO', 'geolocation.getCurrentPosition', arguments);
+        options = parseParameters(options);
+
+        var id = utils.createUUID();
+
+        // Tell device to get a position ASAP, and also retrieve a reference to the timeout timer generated in getCurrentPosition
+        timers[id] = geolocation.getCurrentPosition(successCallback, errorCallback, options);
+
+        var fail = function(e) {
+            clearTimeout(timers[id].timer);
+            var err = new PositionError(e.code, e.message);
+            if (errorCallback) {
+                errorCallback(err);
+            }
+        };
+
+        var win = function(p) {
+            clearTimeout(timers[id].timer);
+            if (options.timeout !== Infinity) {
+                timers[id].timer = createTimeout(fail, options.timeout);
+            }
+            var pos = new Position(
+                {
+                    latitude:p.latitude,
+                    longitude:p.longitude,
+                    altitude:p.altitude,
+                    accuracy:p.accuracy,
+                    heading:p.heading,
+                    velocity:p.velocity,
+                    altitudeAccuracy:p.altitudeAccuracy
+                },
+                (p.timestamp === undefined ? new Date() : ((p.timestamp instanceof Date) ? p.timestamp : new Date(p.timestamp)))
+            );
+            geolocation.lastPosition = pos;
+            successCallback(pos);
+        };
+
+        exec(win, fail, "Geolocation", "addWatch", [id, options.enableHighAccuracy]);
+
+        return id;
+    },
+    /**
+     * Clears the specified heading watch.
+     *
+     * @param {String} id       The ID of the watch returned from #watchPosition
+     */
+    clearWatch:function(id) {
+        if (id && timers[id] !== undefined) {
+            clearTimeout(timers[id].timer);
+            timers[id].timer = false;
+            exec(null, null, "Geolocation", "clearWatch", [id]);
+        }
+    }
+};
+
+module.exports = geolocation;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.globalization/src/firefoxos/GlobalizationProxy.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.globalization/src/firefoxos/GlobalizationProxy.js
@@ -1,0 +1,263 @@
+cordova.define("org.apache.cordova.globalization.GlobalizationProxy", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var GlobalizationError = require('./GlobalizationError');
+
+var l10n_loaded = new Event('l10n_loaded');
+var l10n_ready = new Event('l10n_ready');
+
+var is_l10n_ready = false;
+
+document.addEventListener('l10n_loaded', function() {
+  console.log('DEBUG: L10n loaded');
+  navigator.mozL10n.ready(function() {
+    console.log('DEBUG: L10n ready');
+    is_l10n_ready = true;
+    document.dispatchEvent(l10n_ready);
+  });
+});
+
+function callIfL10nReady(callback) {
+    if (is_l10n_ready) {
+        return callback();
+    }
+    document.addEventListener('l10n_ready', callback);
+}
+
+
+function loadFile(elementName, attributes, callback) {
+    var e = document.createElement(elementName);
+    for (var attrName in attributes) {
+      if(attributes.hasOwnProperty(attrName)) {
+        e.setAttribute(attrName, attributes[attrName]);
+      }
+    }
+    e.onreadystatechange = e.onload = function() {
+        var state = e.readyState;
+        if (!callback.done && (!state || /loaded|complete/.test(state))) {
+            callback.done = true;
+            callback();
+        }
+    };
+    document.head.appendChild(e);
+}
+
+function loadDependencies() {
+  // Adding globalization file to the HEAD section
+  // <link rel="resource" type="application/l10n" href="locales/date.ini" />
+
+  loadFile('link', {
+    'rel': 'resource', 
+    'type': 'application/l10n', 
+    'href': 'locales/date.ini'}, function() {});
+  loadFile('script', {
+    'type': 'text/javascript',
+    'src': 'js/l10n.js'},
+    function() {
+      loadFile('script', {
+        'type': 'text/javascript',
+        'src': 'js/l10n_date.js'},
+        function() {
+          document.dispatchEvent(l10n_loaded);
+        });
+    });
+}
+
+loadDependencies();
+
+function getPreferredLanguage(successCB, errorCB) {
+    // WARNING: this isn't perfect - there is a difference between UI language
+    // and preferred language, however it doesn't happen too often.
+    callIfL10nReady(function() {
+      successCB({value: navigator.mozL10n.language.code});
+    });
+}
+
+function getLocaleName(successCB, errorCB) {
+    callIfL10nReady(function() {
+      successCB(navigator.mozL10n.language.code);
+    });
+}
+
+function dateToString(successCB, errorCB, params) {
+    var date = new Date(params[0].date);
+    var options = params[0].options;
+
+    callIfL10nReady(function() {
+      var f = new navigator.mozL10n.DateTimeFormat();
+      successCB({'value': _getStringFromDate(f, date, options)});
+    });
+
+    function _getStringFromDate(f, date, options) {
+        var format = navigator.mozL10n.get('shortDateTimeFormat');
+        if (options) {
+          if (options.selector == 'date') {
+            return f.localeDateString(date);
+          }
+          if (options.selector == 'time') {
+            return f.localeTimeString(date);
+          }
+          if (options.formatLength != 'short') {
+            format = navigator.mozL10n.get('dateTimeFormat');
+            return f.localeString(date, format);
+          }
+          if (options.selector == 'time') {
+            return f.localeTimeString(date, format);
+          }
+        }
+        var d = f.localeDateString(date);
+        var t = f.localeTimeString(date);
+        return d + ' ' + t;
+    }
+}
+
+function stringToDate(successCB, errorCB, params) {
+    var date;
+    var dateString = params[0].dateString;
+    var options = params[0].options;
+    try {
+      date = new Date(dateString);
+    } catch(e) {  
+      console.log("Cordova, stringToDate, An error occurred " + e.message);
+      return errorCB(GlobalizationError(
+            GlobalizationError.PARSING_ERROR, e.message));
+    } 
+    if (!date || date == 'Invalid Date') {
+      console.log("Cordova, stringToDate, Invalid Date: " + dateString);
+      return errorCB(GlobalizationError(
+            GlobalizationError.PARSING_ERROR, 'Invalid Date (' + dateString + ')'));
+    }
+
+    var dateObj = {
+      'year': date.getFullYear(),
+      'month': date.getMonth(),
+      'day': date.getDay() 
+    };
+    var timeObj = {
+      'hour': date.getHours(),
+      'minute': date.getMinutes(),
+      'second': date.getSeconds(),
+      'millisecond': date.getMilliseconds() 
+    };
+    if (options) {
+      if (options.selector == 'date') {
+        return successCB(dateObj);
+      }
+      if (options.selector == 'time') {
+        return successCB(timeObj);
+      }
+    }
+    for (var i in timeObj) {
+      if (timeObj.hasOwnProperty(i)) {
+        dateObj[i] = timeObj[i];
+      }
+    }
+    successCB(dateObj);
+}
+
+function getDatePattern(successCB, failureCB, options) {
+    failureCB(GlobalizationError.UNKNOWN_ERROR, 'unsupported');
+}
+
+function getDateNames(successCB, failureCB, params) {
+  callIfL10nReady(function() {
+    var version = 'long';
+    var item = 'month';
+    var first = 0;
+    var options = params[0].options;
+    if (options) {
+      if (options.type == 'narrow') {
+        version = 'short';
+      } else if (options.type == 'genitive' && options.item == 'months') {
+        version = options.type;
+      } 
+      if (options.item == 'days') {
+        item = 'weekday';
+        first = parseInt(navigator.mozL10n.get('weekStartsOnMonday'));
+      }
+    }
+    var limit = (item == 'month') ? 11 : 6;
+
+    var arr = [];
+    for (var i = first; i <= first + limit; i++) {
+        arr.push(navigator.mozL10n.get(item + '-' + i % (limit + 1) + '-' + version));
+    }
+    successCB({'value': arr});
+  });
+}
+
+Date.prototype.stdTimezoneOffset = function() {
+    // Return the standard timezone offset (usually 0 or -600)
+    var jan = new Date(this.getFullYear(), 0, 1);
+    var jul = new Date(this.getFullYear(), 6, 1);
+    return Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
+};
+
+Date.prototype.isDayLightSavingsTime = function() {
+    return this.getTimezoneOffset() < this.stdTimezoneOffset();
+};
+
+function isDayLightSavingsTime(successCB, failureCB, params) {
+    var date = new Date(params[0].date);
+    successCB({'dst': date.isDayLightSavingsTime()});
+}
+
+function getFirstDayOfWeek(successCB, failureCB) {
+  callIfL10nReady(function() {
+    var firstDay = navigator.mozL10n.get('weekStartsOnMonday');
+    successCB({'value': parseInt(firstDay)});
+  });
+}
+
+function numberToString(number, successCB, failureCB) {
+    failureCB(GlobalizationError.UNKNOWN_ERROR, 'unsupported');
+}
+
+function stringToNumber(numberString, successCB, failureCB, options) {
+    failureCB(GlobalizationError.UNKNOWN_ERROR, 'unsupported');
+}
+
+function getNumberPattern(successCB, failureCB, options) {
+    failureCB(GlobalizationError.UNKNOWN_ERROR, 'unsupported');
+}
+
+function getCurrencyPattern(currencyCode, successCB, failureCB) {
+    failureCB(GlobalizationError.UNKNOWN_ERROR, 'unsupported');
+}
+
+var Globalization = {
+    getLocaleName: getLocaleName,
+    getPreferredLanguage: getPreferredLanguage,
+    dateToString: dateToString,
+    stringToDate: stringToDate,
+    getDatePattern: getDatePattern,
+    getDateNames: getDateNames,
+    isDayLightSavingsTime: isDayLightSavingsTime,
+    getFirstDayOfWeek: getFirstDayOfWeek,
+    numberToString: numberToString,
+    stringToNumber: stringToNumber,
+    getNumberPattern: getNumberPattern,
+    getCurrencyPattern: getCurrencyPattern
+};
+
+require("cordova/exec/proxy").add("Globalization", Globalization);
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.globalization/www/GlobalizationError.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.globalization/www/GlobalizationError.js
@@ -1,0 +1,43 @@
+cordova.define("org.apache.cordova.globalization.GlobalizationError", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+
+/**
+ * Globalization error object
+ *
+ * @constructor
+ * @param code
+ * @param message
+ */
+var GlobalizationError = function(code, message) {
+    this.code = code || null;
+    this.message = message || '';
+};
+
+// Globalization error codes
+GlobalizationError.UNKNOWN_ERROR = 0;
+GlobalizationError.FORMATTING_ERROR = 1;
+GlobalizationError.PARSING_ERROR = 2;
+GlobalizationError.PATTERN_ERROR = 3;
+
+module.exports = GlobalizationError;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.globalization/www/globalization.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.globalization/www/globalization.js
@@ -1,0 +1,393 @@
+cordova.define("org.apache.cordova.globalization.globalization", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    exec = require('cordova/exec'),
+    GlobalizationError = require('./GlobalizationError');
+
+var globalization = {
+
+/**
+* Returns the string identifier for the client's current language.
+* It returns the language identifier string to the successCB callback with a
+* properties object as a parameter. If there is an error getting the language,
+* then the errorCB callback is invoked.
+*
+* @param {Function} successCB
+* @param {Function} errorCB
+*
+* @return Object.value {String}: The language identifier
+*
+* @error GlobalizationError.UNKNOWN_ERROR
+*
+* Example
+*    globalization.getPreferredLanguage(function (language) {alert('language:' + language.value + '\n');},
+*                                function () {});
+*/
+getPreferredLanguage:function(successCB, failureCB) {
+    argscheck.checkArgs('fF', 'Globalization.getPreferredLanguage', arguments);
+    exec(successCB, failureCB, "Globalization","getPreferredLanguage", []);
+},
+
+/**
+* Returns the string identifier for the client's current locale setting.
+* It returns the locale identifier string to the successCB callback with a
+* properties object as a parameter. If there is an error getting the locale,
+* then the errorCB callback is invoked.
+*
+* @param {Function} successCB
+* @param {Function} errorCB
+*
+* @return Object.value {String}: The locale identifier
+*
+* @error GlobalizationError.UNKNOWN_ERROR
+*
+* Example
+*    globalization.getLocaleName(function (locale) {alert('locale:' + locale.value + '\n');},
+*                                function () {});
+*/
+getLocaleName:function(successCB, failureCB) {
+    argscheck.checkArgs('fF', 'Globalization.getLocaleName', arguments);
+    exec(successCB, failureCB, "Globalization","getLocaleName", []);
+},
+
+
+/**
+* Returns a date formatted as a string according to the client's user preferences and
+* calendar using the time zone of the client. It returns the formatted date string to the
+* successCB callback with a properties object as a parameter. If there is an error
+* formatting the date, then the errorCB callback is invoked.
+*
+* The defaults are: formatLenght="short" and selector="date and time"
+*
+* @param {Date} date
+* @param {Function} successCB
+* @param {Function} errorCB
+* @param {Object} options {optional}
+*            formatLength {String}: 'short', 'medium', 'long', or 'full'
+*            selector {String}: 'date', 'time', or 'date and time'
+*
+* @return Object.value {String}: The localized date string
+*
+* @error GlobalizationError.FORMATTING_ERROR
+*
+* Example
+*    globalization.dateToString(new Date(),
+*                function (date) {alert('date:' + date.value + '\n');},
+*                function (errorCode) {alert(errorCode);},
+*                {formatLength:'short'});
+*/
+dateToString:function(date, successCB, failureCB, options) {
+    argscheck.checkArgs('dfFO', 'Globalization.dateToString', arguments);
+    var dateValue = date.valueOf();
+    exec(successCB, failureCB, "Globalization", "dateToString", [{"date": dateValue, "options": options}]);
+},
+
+
+/**
+* Parses a date formatted as a string according to the client's user
+* preferences and calendar using the time zone of the client and returns
+* the corresponding date object. It returns the date to the successCB
+* callback with a properties object as a parameter. If there is an error
+* parsing the date string, then the errorCB callback is invoked.
+*
+* The defaults are: formatLength="short" and selector="date and time"
+*
+* @param {String} dateString
+* @param {Function} successCB
+* @param {Function} errorCB
+* @param {Object} options {optional}
+*            formatLength {String}: 'short', 'medium', 'long', or 'full'
+*            selector {String}: 'date', 'time', or 'date and time'
+*
+* @return    Object.year {Number}: The four digit year
+*            Object.month {Number}: The month from (0 - 11)
+*            Object.day {Number}: The day from (1 - 31)
+*            Object.hour {Number}: The hour from (0 - 23)
+*            Object.minute {Number}: The minute from (0 - 59)
+*            Object.second {Number}: The second from (0 - 59)
+*            Object.millisecond {Number}: The milliseconds (from 0 - 999),
+*                                        not available on all platforms
+*
+* @error GlobalizationError.PARSING_ERROR
+*
+* Example
+*    globalization.stringToDate('4/11/2011',
+*                function (date) { alert('Month:' + date.month + '\n' +
+*                    'Day:' + date.day + '\n' +
+*                    'Year:' + date.year + '\n');},
+*                function (errorCode) {alert(errorCode);},
+*                {selector:'date'});
+*/
+stringToDate:function(dateString, successCB, failureCB, options) {
+    argscheck.checkArgs('sfFO', 'Globalization.stringToDate', arguments);
+    exec(successCB, failureCB, "Globalization", "stringToDate", [{"dateString": dateString, "options": options}]);
+},
+
+
+/**
+* Returns a pattern string for formatting and parsing dates according to the client's
+* user preferences. It returns the pattern to the successCB callback with a
+* properties object as a parameter. If there is an error obtaining the pattern,
+* then the errorCB callback is invoked.
+*
+* The defaults are: formatLength="short" and selector="date and time"
+*
+* @param {Function} successCB
+* @param {Function} errorCB
+* @param {Object} options {optional}
+*            formatLength {String}: 'short', 'medium', 'long', or 'full'
+*            selector {String}: 'date', 'time', or 'date and time'
+*
+* @return    Object.pattern {String}: The date and time pattern for formatting and parsing dates.
+*                                    The patterns follow Unicode Technical Standard #35
+*                                    http://unicode.org/reports/tr35/tr35-4.html
+*            Object.timezone {String}: The abbreviated name of the time zone on the client
+*            Object.utc_offset {Number}: The current difference in seconds between the client's
+*                                        time zone and coordinated universal time.
+*            Object.dst_offset {Number}: The current daylight saving time offset in seconds
+*                                        between the client's non-daylight saving's time zone
+*                                        and the client's daylight saving's time zone.
+*
+* @error GlobalizationError.PATTERN_ERROR
+*
+* Example
+*    globalization.getDatePattern(
+*                function (date) {alert('pattern:' + date.pattern + '\n');},
+*                function () {},
+*                {formatLength:'short'});
+*/
+getDatePattern:function(successCB, failureCB, options) {
+    argscheck.checkArgs('fFO', 'Globalization.getDatePattern', arguments);
+    exec(successCB, failureCB, "Globalization", "getDatePattern", [{"options": options}]);
+},
+
+
+/**
+* Returns an array of either the names of the months or days of the week
+* according to the client's user preferences and calendar. It returns the array of names to the
+* successCB callback with a properties object as a parameter. If there is an error obtaining the
+* names, then the errorCB callback is invoked.
+*
+* The defaults are: type="wide" and item="months"
+*
+* @param {Function} successCB
+* @param {Function} errorCB
+* @param {Object} options {optional}
+*            type {String}: 'narrow' or 'wide'
+*            item {String}: 'months', or 'days'
+*
+* @return Object.value {Array{String}}: The array of names starting from either
+*                                        the first month in the year or the
+*                                        first day of the week.
+* @error GlobalizationError.UNKNOWN_ERROR
+*
+* Example
+*    globalization.getDateNames(function (names) {
+*        for(var i = 0; i < names.value.length; i++) {
+*            alert('Month:' + names.value[i] + '\n');}},
+*        function () {});
+*/
+getDateNames:function(successCB, failureCB, options) {
+    argscheck.checkArgs('fFO', 'Globalization.getDateNames', arguments);
+    exec(successCB, failureCB, "Globalization", "getDateNames", [{"options": options}]);
+},
+
+/**
+* Returns whether daylight savings time is in effect for a given date using the client's
+* time zone and calendar. It returns whether or not daylight savings time is in effect
+* to the successCB callback with a properties object as a parameter. If there is an error
+* reading the date, then the errorCB callback is invoked.
+*
+* @param {Date} date
+* @param {Function} successCB
+* @param {Function} errorCB
+*
+* @return Object.dst {Boolean}: The value "true" indicates that daylight savings time is
+*                                in effect for the given date and "false" indicate that it is not.
+*
+* @error GlobalizationError.UNKNOWN_ERROR
+*
+* Example
+*    globalization.isDayLightSavingsTime(new Date(),
+*                function (date) {alert('dst:' + date.dst + '\n');}
+*                function () {});
+*/
+isDayLightSavingsTime:function(date, successCB, failureCB) {
+    argscheck.checkArgs('dfF', 'Globalization.isDayLightSavingsTime', arguments);
+    var dateValue = date.valueOf();
+    exec(successCB, failureCB, "Globalization", "isDayLightSavingsTime", [{"date": dateValue}]);
+},
+
+/**
+* Returns the first day of the week according to the client's user preferences and calendar.
+* The days of the week are numbered starting from 1 where 1 is considered to be Sunday.
+* It returns the day to the successCB callback with a properties object as a parameter.
+* If there is an error obtaining the pattern, then the errorCB callback is invoked.
+*
+* @param {Function} successCB
+* @param {Function} errorCB
+*
+* @return Object.value {Number}: The number of the first day of the week.
+*
+* @error GlobalizationError.UNKNOWN_ERROR
+*
+* Example
+*    globalization.getFirstDayOfWeek(function (day)
+*                { alert('Day:' + day.value + '\n');},
+*                function () {});
+*/
+getFirstDayOfWeek:function(successCB, failureCB) {
+    argscheck.checkArgs('fF', 'Globalization.getFirstDayOfWeek', arguments);
+    exec(successCB, failureCB, "Globalization", "getFirstDayOfWeek", []);
+},
+
+
+/**
+* Returns a number formatted as a string according to the client's user preferences.
+* It returns the formatted number string to the successCB callback with a properties object as a
+* parameter. If there is an error formatting the number, then the errorCB callback is invoked.
+*
+* The defaults are: type="decimal"
+*
+* @param {Number} number
+* @param {Function} successCB
+* @param {Function} errorCB
+* @param {Object} options {optional}
+*            type {String}: 'decimal', "percent", or 'currency'
+*
+* @return Object.value {String}: The formatted number string.
+*
+* @error GlobalizationError.FORMATTING_ERROR
+*
+* Example
+*    globalization.numberToString(3.25,
+*                function (number) {alert('number:' + number.value + '\n');},
+*                function () {},
+*                {type:'decimal'});
+*/
+numberToString:function(number, successCB, failureCB, options) {
+    argscheck.checkArgs('nfFO', 'Globalization.numberToString', arguments);
+    exec(successCB, failureCB, "Globalization", "numberToString", [{"number": number, "options": options}]);
+},
+
+/**
+* Parses a number formatted as a string according to the client's user preferences and
+* returns the corresponding number. It returns the number to the successCB callback with a
+* properties object as a parameter. If there is an error parsing the number string, then
+* the errorCB callback is invoked.
+*
+* The defaults are: type="decimal"
+*
+* @param {String} numberString
+* @param {Function} successCB
+* @param {Function} errorCB
+* @param {Object} options {optional}
+*            type {String}: 'decimal', "percent", or 'currency'
+*
+* @return Object.value {Number}: The parsed number.
+*
+* @error GlobalizationError.PARSING_ERROR
+*
+* Example
+*    globalization.stringToNumber('1234.56',
+*                function (number) {alert('Number:' + number.value + '\n');},
+*                function () { alert('Error parsing number');});
+*/
+stringToNumber:function(numberString, successCB, failureCB, options) {
+    argscheck.checkArgs('sfFO', 'Globalization.stringToNumber', arguments);
+    exec(successCB, failureCB, "Globalization", "stringToNumber", [{"numberString": numberString, "options": options}]);
+},
+
+/**
+* Returns a pattern string for formatting and parsing numbers according to the client's user
+* preferences. It returns the pattern to the successCB callback with a properties object as a
+* parameter. If there is an error obtaining the pattern, then the errorCB callback is invoked.
+*
+* The defaults are: type="decimal"
+*
+* @param {Function} successCB
+* @param {Function} errorCB
+* @param {Object} options {optional}
+*            type {String}: 'decimal', "percent", or 'currency'
+*
+* @return    Object.pattern {String}: The number pattern for formatting and parsing numbers.
+*                                    The patterns follow Unicode Technical Standard #35.
+*                                    http://unicode.org/reports/tr35/tr35-4.html
+*            Object.symbol {String}: The symbol to be used when formatting and parsing
+*                                    e.g., percent or currency symbol.
+*            Object.fraction {Number}: The number of fractional digits to use when parsing and
+*                                    formatting numbers.
+*            Object.rounding {Number}: The rounding increment to use when parsing and formatting.
+*            Object.positive {String}: The symbol to use for positive numbers when parsing and formatting.
+*            Object.negative: {String}: The symbol to use for negative numbers when parsing and formatting.
+*            Object.decimal: {String}: The decimal symbol to use for parsing and formatting.
+*            Object.grouping: {String}: The grouping symbol to use for parsing and formatting.
+*
+* @error GlobalizationError.PATTERN_ERROR
+*
+* Example
+*    globalization.getNumberPattern(
+*                function (pattern) {alert('Pattern:' + pattern.pattern + '\n');},
+*                function () {});
+*/
+getNumberPattern:function(successCB, failureCB, options) {
+    argscheck.checkArgs('fFO', 'Globalization.getNumberPattern', arguments);
+    exec(successCB, failureCB, "Globalization", "getNumberPattern", [{"options": options}]);
+},
+
+/**
+* Returns a pattern string for formatting and parsing currency values according to the client's
+* user preferences and ISO 4217 currency code. It returns the pattern to the successCB callback with a
+* properties object as a parameter. If there is an error obtaining the pattern, then the errorCB
+* callback is invoked.
+*
+* @param {String} currencyCode
+* @param {Function} successCB
+* @param {Function} errorCB
+*
+* @return    Object.pattern {String}: The currency pattern for formatting and parsing currency values.
+*                                    The patterns follow Unicode Technical Standard #35
+*                                    http://unicode.org/reports/tr35/tr35-4.html
+*            Object.code {String}: The ISO 4217 currency code for the pattern.
+*            Object.fraction {Number}: The number of fractional digits to use when parsing and
+*                                    formatting currency.
+*            Object.rounding {Number}: The rounding increment to use when parsing and formatting.
+*            Object.decimal: {String}: The decimal symbol to use for parsing and formatting.
+*            Object.grouping: {String}: The grouping symbol to use for parsing and formatting.
+*
+* @error GlobalizationError.FORMATTING_ERROR
+*
+* Example
+*    globalization.getCurrencyPattern('EUR',
+*                function (currency) {alert('Pattern:' + currency.pattern + '\n');}
+*                function () {});
+*/
+getCurrencyPattern:function(currencyCode, successCB, failureCB) {
+    argscheck.checkArgs('sfF', 'Globalization.getCurrencyPattern', arguments);
+    exec(successCB, failureCB, "Globalization", "getCurrencyPattern", [{"currencyCode": currencyCode}]);
+}
+
+};
+
+module.exports = globalization;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.inappbrowser/src/firefoxos/InAppBrowserProxy.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.inappbrowser/src/firefoxos/InAppBrowserProxy.js
@@ -1,0 +1,192 @@
+cordova.define("org.apache.cordova.inappbrowser.InAppBrowserProxy", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+// https://developer.mozilla.org/en-US/docs/WebAPI/Browser
+
+var cordova = require('cordova'),
+    channel = require('cordova/channel'),
+    modulemapper = require('cordova/modulemapper');
+
+var origOpenFunc = modulemapper.getOriginalSymbol(window, 'window.open');
+var browserWrap;
+
+var IABExecs = {
+
+    close: function (win, lose) {
+        if (browserWrap) {
+            browserWrap.parentNode.removeChild(browserWrap);
+            browserWrap = null;
+            if (typeof(win) == "function") win({type:'exit'});
+        }
+    },
+
+    /*
+     * Reveal browser if opened hidden
+     */
+    show: function (win, lose) {
+        console.error('[FirefoxOS] show not implemented');
+    },
+
+    open: function (win, lose, args) {
+        var strUrl = args[0],
+            target = args[1],
+            features_string = args[2] || "location=yes", //location=yes is default
+            features = {},
+            url,
+            elem;
+
+        var features_list = features_string.split(',');
+        features_list.forEach(function(feature) {
+            var tup = feature.split('=');
+            if (tup[1] == 'yes') {
+                tup[1] = true;
+            } else if (tup[1] == 'no') {
+                tup[1] = false;
+            } else {
+                var number = parseInt(tup[1]);    
+                if (!isNaN(number)) {
+                    tup[1] = number;
+                }
+            }
+            features[tup[0]] = tup[1];
+        });
+
+        function updateIframeSizeNoLocation() {
+            browserWrap.style.width = window.innerWidth + 'px';
+            browserWrap.style.height = window.innerHeight + 'px';
+            browserWrap.browser.style.height = (window.innerHeight - 60) + 'px';
+            browserWrap.browser.style.width = browserWrap.style.width;
+        }
+
+        if (target === '_system') {
+            origOpenFunc.apply(window, [strUrl, '_blank']);
+        } else if (target === '_blank') {
+            var browserElem = document.createElement('iframe');
+            browserElem.setAttribute('mozbrowser', true);
+            // make this loaded in its own child process
+            browserElem.setAttribute('remote', true);
+            browserElem.setAttribute('src', strUrl);
+            if (browserWrap) {
+                document.body.removeChild(browserWrap);
+            }
+            browserWrap = document.createElement('div');
+            // assign browser element to browserWrap for future reference
+            browserWrap.browser = browserElem;
+
+            browserWrap.classList.add('inAppBrowserWrap');
+            // position fixed so that it works even when page is scrolled
+            browserWrap.style.position = 'fixed';
+            browserElem.style.position = 'absolute';
+            browserElem.style.border = 0;
+            browserElem.style.top = '60px';
+            browserElem.style.left = '0px';
+            updateIframeSizeNoLocation();
+
+            var menu = document.createElement('menu');
+            menu.setAttribute('type', 'toolbar');
+            var close = document.createElement('li');
+            var back = document.createElement('li');
+            var forward = document.createElement('li');
+
+            close.appendChild(document.createTextNode('×'));
+            back.appendChild(document.createTextNode('<'));
+            forward.appendChild(document.createTextNode('>'));
+
+            close.classList.add('inAppBrowserClose');
+            back.classList.add('inAppBrowserBack');
+            forward.classList.add('inAppBrowserForward');
+
+            function checkForwardBackward() {
+                var backReq = browserElem.getCanGoBack();
+                backReq.onsuccess = function() {
+                    if (this.result) {
+                        back.classList.remove('disabled');
+                    } else {
+                        back.classList.add('disabled');
+                    }
+                }
+                var forwardReq = browserElem.getCanGoForward();
+                forwardReq.onsuccess = function() {
+                    if (this.result) {
+                        forward.classList.remove('disabled');
+                    } else {
+                        forward.classList.add('disabled');
+                    }
+                }
+            };
+
+            browserElem.addEventListener('mozbrowserloadend', checkForwardBackward);
+
+            close.addEventListener('click', function () {
+                setTimeout(function () {
+                    IABExecs.close(win, lose);
+                }, 0);
+            }, false);
+
+            back.addEventListener('click', function () {
+                browserElem.goBack();
+            }, false);
+
+            forward.addEventListener('click', function () {
+                browserElem.goForward();
+            }, false);
+
+            menu.appendChild(back);
+            menu.appendChild(forward);
+            menu.appendChild(close);
+
+            browserWrap.appendChild(menu);
+            browserWrap.appendChild(browserElem);
+            document.body.appendChild(browserWrap);
+
+            //we use mozbrowserlocationchange instead of mozbrowserloadstart to get the url
+            browserElem.addEventListener('mozbrowserlocationchange', function(e){
+                win({
+                    type:'loadstart',
+                    url : e.detail
+                })
+            }, false);
+            browserElem.addEventListener('mozbrowserloadend', function(e){
+                win({type:'loadstop'})
+            }, false);
+            browserElem.addEventListener('mozbrowsererror', function(e){
+                win({type:'loaderror'})
+            }, false);
+            browserElem.addEventListener('mozbrowserclose', function(e){
+                win({type:'exit'})
+            }, false);
+        } else {
+            window.location = strUrl;
+        }
+    },
+    injectScriptCode: function (code, bCB) {
+        console.error('[FirefoxOS] injectScriptCode not implemented');
+    },
+    injectScriptFile: function (file, bCB) {
+        console.error('[FirefoxOS] injectScriptFile not implemented');
+    }
+};
+
+module.exports = IABExecs;
+
+require('cordova/exec/proxy').add('InAppBrowser', module.exports);
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.inappbrowser/www/inappbrowser.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.inappbrowser/www/inappbrowser.js
@@ -1,0 +1,100 @@
+cordova.define("org.apache.cordova.inappbrowser.inappbrowser", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var exec = require('cordova/exec');
+var channel = require('cordova/channel');
+var modulemapper = require('cordova/modulemapper');
+var urlutil = require('cordova/urlutil');
+
+function InAppBrowser() {
+   this.channels = {
+        'loadstart': channel.create('loadstart'),
+        'loadstop' : channel.create('loadstop'),
+        'loaderror' : channel.create('loaderror'),
+        'exit' : channel.create('exit')
+   };
+}
+
+InAppBrowser.prototype = {
+    _eventHandler: function (event) {
+        if (event.type in this.channels) {
+            this.channels[event.type].fire(event);
+        }
+    },
+    close: function (eventname) {
+        exec(null, null, "InAppBrowser", "close", []);
+    },
+    show: function (eventname) {
+      exec(null, null, "InAppBrowser", "show", []);
+    },
+    addEventListener: function (eventname,f) {
+        if (eventname in this.channels) {
+            this.channels[eventname].subscribe(f);
+        }
+    },
+    removeEventListener: function(eventname, f) {
+        if (eventname in this.channels) {
+            this.channels[eventname].unsubscribe(f);
+        }
+    },
+
+    executeScript: function(injectDetails, cb) {
+        if (injectDetails.code) {
+            exec(cb, null, "InAppBrowser", "injectScriptCode", [injectDetails.code, !!cb]);
+        } else if (injectDetails.file) {
+            exec(cb, null, "InAppBrowser", "injectScriptFile", [injectDetails.file, !!cb]);
+        } else {
+            throw new Error('executeScript requires exactly one of code or file to be specified');
+        }
+    },
+
+    insertCSS: function(injectDetails, cb) {
+        if (injectDetails.code) {
+            exec(cb, null, "InAppBrowser", "injectStyleCode", [injectDetails.code, !!cb]);
+        } else if (injectDetails.file) {
+            exec(cb, null, "InAppBrowser", "injectStyleFile", [injectDetails.file, !!cb]);
+        } else {
+            throw new Error('insertCSS requires exactly one of code or file to be specified');
+        }
+    }
+};
+
+module.exports = function(strUrl, strWindowName, strWindowFeatures) {
+    // Don't catch calls that write to existing frames (e.g. named iframes).
+    if (window.frames && window.frames[strWindowName]) {
+        var origOpenFunc = modulemapper.getOriginalSymbol(window, 'open');
+        return origOpenFunc.apply(window, arguments);
+    }
+
+    strUrl = urlutil.makeAbsolute(strUrl);
+    var iab = new InAppBrowser();
+    var cb = function(eventname) {
+       iab._eventHandler(eventname);
+    };
+
+    strWindowFeatures = strWindowFeatures || "";
+
+    exec(cb, cb, "InAppBrowser", "open", [strUrl, strWindowName, strWindowFeatures]);
+    return iab;
+};
+
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media-capture/www/CaptureAudioOptions.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media-capture/www/CaptureAudioOptions.js
@@ -1,0 +1,34 @@
+cordova.define("org.apache.cordova.media-capture.CaptureAudioOptions", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * Encapsulates all audio capture operation configuration options.
+ */
+var CaptureAudioOptions = function(){
+    // Upper limit of sound clips user can record. Value must be equal or greater than 1.
+    this.limit = 1;
+    // Maximum duration of a single sound clip in seconds.
+    this.duration = 0;
+};
+
+module.exports = CaptureAudioOptions;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media-capture/www/CaptureError.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media-capture/www/CaptureError.js
@@ -1,0 +1,42 @@
+cordova.define("org.apache.cordova.media-capture.CaptureError", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * The CaptureError interface encapsulates all errors in the Capture API.
+ */
+var CaptureError = function(c) {
+   this.code = c || null;
+};
+
+// Camera or microphone failed to capture image or sound.
+CaptureError.CAPTURE_INTERNAL_ERR = 0;
+// Camera application or audio capture application is currently serving other capture request.
+CaptureError.CAPTURE_APPLICATION_BUSY = 1;
+// Invalid use of the API (e.g. limit parameter has value less than one).
+CaptureError.CAPTURE_INVALID_ARGUMENT = 2;
+// User exited camera application or audio capture application before capturing anything.
+CaptureError.CAPTURE_NO_MEDIA_FILES = 3;
+// The requested capture operation is not supported.
+CaptureError.CAPTURE_NOT_SUPPORTED = 20;
+
+module.exports = CaptureError;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media-capture/www/CaptureImageOptions.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media-capture/www/CaptureImageOptions.js
@@ -1,0 +1,32 @@
+cordova.define("org.apache.cordova.media-capture.CaptureImageOptions", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * Encapsulates all image capture operation configuration options.
+ */
+var CaptureImageOptions = function(){
+    // Upper limit of images user can take. Value must be equal or greater than 1.
+    this.limit = 1;
+};
+
+module.exports = CaptureImageOptions;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media-capture/www/CaptureVideoOptions.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media-capture/www/CaptureVideoOptions.js
@@ -1,0 +1,34 @@
+cordova.define("org.apache.cordova.media-capture.CaptureVideoOptions", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * Encapsulates all video capture operation configuration options.
+ */
+var CaptureVideoOptions = function(){
+    // Upper limit of videos user can record. Value must be equal or greater than 1.
+    this.limit = 1;
+    // Maximum duration of a single video clip in seconds.
+    this.duration = 0;
+};
+
+module.exports = CaptureVideoOptions;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media-capture/www/MediaFile.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media-capture/www/MediaFile.js
@@ -1,0 +1,57 @@
+cordova.define("org.apache.cordova.media-capture.MediaFile", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var utils = require('cordova/utils'),
+    exec = require('cordova/exec'),
+    File = require('org.apache.cordova.file.File'),
+    CaptureError = require('./CaptureError');
+/**
+ * Represents a single file.
+ *
+ * name {DOMString} name of the file, without path information
+ * fullPath {DOMString} the full path of the file, including the name
+ * type {DOMString} mime type
+ * lastModifiedDate {Date} last modified date
+ * size {Number} size of the file in bytes
+ */
+var MediaFile = function(name, localURL, type, lastModifiedDate, size){
+    MediaFile.__super__.constructor.apply(this, arguments);
+};
+
+utils.extend(MediaFile, File);
+
+/**
+ * Request capture format data for a specific file and type
+ *
+ * @param {Function} successCB
+ * @param {Function} errorCB
+ */
+MediaFile.prototype.getFormatData = function(successCallback, errorCallback) {
+    if (typeof this.fullPath === "undefined" || this.fullPath === null) {
+        errorCallback(new CaptureError(CaptureError.CAPTURE_INVALID_ARGUMENT));
+    } else {
+        exec(successCallback, errorCallback, "Capture", "getFormatData", [this.localURL, this.type]);
+    }
+};
+
+module.exports = MediaFile;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media-capture/www/MediaFileData.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media-capture/www/MediaFileData.js
@@ -1,0 +1,41 @@
+cordova.define("org.apache.cordova.media-capture.MediaFileData", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * MediaFileData encapsulates format information of a media file.
+ *
+ * @param {DOMString} codecs
+ * @param {long} bitrate
+ * @param {long} height
+ * @param {long} width
+ * @param {float} duration
+ */
+var MediaFileData = function(codecs, bitrate, height, width, duration){
+    this.codecs = codecs || null;
+    this.bitrate = bitrate || 0;
+    this.height = height || 0;
+    this.width = width || 0;
+    this.duration = duration || 0;
+};
+
+module.exports = MediaFileData;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media-capture/www/capture.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media-capture/www/capture.js
@@ -1,0 +1,98 @@
+cordova.define("org.apache.cordova.media-capture.capture", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var exec = require('cordova/exec'),
+    MediaFile = require('./MediaFile');
+
+/**
+ * Launches a capture of different types.
+ *
+ * @param (DOMString} type
+ * @param {Function} successCB
+ * @param {Function} errorCB
+ * @param {CaptureVideoOptions} options
+ */
+function _capture(type, successCallback, errorCallback, options) {
+    var win = function(pluginResult) {
+        var mediaFiles = [];
+        var i;
+        for (i = 0; i < pluginResult.length; i++) {
+            var mediaFile = new MediaFile();
+            mediaFile.name = pluginResult[i].name;
+
+            // Backwards compatibility
+            mediaFile.localURL = pluginResult[i].localURL || pluginResult[i].fullPath;
+            mediaFile.fullPath = pluginResult[i].fullPath;
+            mediaFile.type = pluginResult[i].type;
+            mediaFile.lastModifiedDate = pluginResult[i].lastModifiedDate;
+            mediaFile.size = pluginResult[i].size;
+            mediaFiles.push(mediaFile);
+        }
+        successCallback(mediaFiles);
+    };
+    exec(win, errorCallback, "Capture", type, [options]);
+}
+/**
+ * The Capture interface exposes an interface to the camera and microphone of the hosting device.
+ */
+function Capture() {
+    this.supportedAudioModes = [];
+    this.supportedImageModes = [];
+    this.supportedVideoModes = [];
+}
+
+/**
+ * Launch audio recorder application for recording audio clip(s).
+ *
+ * @param {Function} successCB
+ * @param {Function} errorCB
+ * @param {CaptureAudioOptions} options
+ */
+Capture.prototype.captureAudio = function(successCallback, errorCallback, options){
+    _capture("captureAudio", successCallback, errorCallback, options);
+};
+
+/**
+ * Launch camera application for taking image(s).
+ *
+ * @param {Function} successCB
+ * @param {Function} errorCB
+ * @param {CaptureImageOptions} options
+ */
+Capture.prototype.captureImage = function(successCallback, errorCallback, options){
+    _capture("captureImage", successCallback, errorCallback, options);
+};
+
+/**
+ * Launch device camera application for recording video(s).
+ *
+ * @param {Function} successCB
+ * @param {Function} errorCB
+ * @param {CaptureVideoOptions} options
+ */
+Capture.prototype.captureVideo = function(successCallback, errorCallback, options){
+    _capture("captureVideo", successCallback, errorCallback, options);
+};
+
+
+module.exports = new Capture();
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media/www/Media.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media/www/Media.js
@@ -1,0 +1,197 @@
+cordova.define("org.apache.cordova.media.Media", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    utils = require('cordova/utils'),
+    exec = require('cordova/exec');
+
+var mediaObjects = {};
+
+/**
+ * This class provides access to the device media, interfaces to both sound and video
+ *
+ * @constructor
+ * @param src                   The file name or url to play
+ * @param successCallback       The callback to be called when the file is done playing or recording.
+ *                                  successCallback()
+ * @param errorCallback         The callback to be called if there is an error.
+ *                                  errorCallback(int errorCode) - OPTIONAL
+ * @param statusCallback        The callback to be called when media status has changed.
+ *                                  statusCallback(int statusCode) - OPTIONAL
+ */
+var Media = function(src, successCallback, errorCallback, statusCallback) {
+    argscheck.checkArgs('SFFF', 'Media', arguments);
+    this.id = utils.createUUID();
+    mediaObjects[this.id] = this;
+    this.src = src;
+    this.successCallback = successCallback;
+    this.errorCallback = errorCallback;
+    this.statusCallback = statusCallback;
+    this._duration = -1;
+    this._position = -1;
+    exec(null, this.errorCallback, "Media", "create", [this.id, this.src]);
+};
+
+// Media messages
+Media.MEDIA_STATE = 1;
+Media.MEDIA_DURATION = 2;
+Media.MEDIA_POSITION = 3;
+Media.MEDIA_ERROR = 9;
+
+// Media states
+Media.MEDIA_NONE = 0;
+Media.MEDIA_STARTING = 1;
+Media.MEDIA_RUNNING = 2;
+Media.MEDIA_PAUSED = 3;
+Media.MEDIA_STOPPED = 4;
+Media.MEDIA_MSG = ["None", "Starting", "Running", "Paused", "Stopped"];
+
+// "static" function to return existing objs.
+Media.get = function(id) {
+    return mediaObjects[id];
+};
+
+/**
+ * Start or resume playing audio file.
+ */
+Media.prototype.play = function(options) {
+    exec(null, null, "Media", "startPlayingAudio", [this.id, this.src, options]);
+};
+
+/**
+ * Stop playing audio file.
+ */
+Media.prototype.stop = function() {
+    var me = this;
+    exec(function() {
+        me._position = 0;
+    }, this.errorCallback, "Media", "stopPlayingAudio", [this.id]);
+};
+
+/**
+ * Seek or jump to a new time in the track..
+ */
+Media.prototype.seekTo = function(milliseconds) {
+    var me = this;
+    exec(function(p) {
+        me._position = p;
+    }, this.errorCallback, "Media", "seekToAudio", [this.id, milliseconds]);
+};
+
+/**
+ * Pause playing audio file.
+ */
+Media.prototype.pause = function() {
+    exec(null, this.errorCallback, "Media", "pausePlayingAudio", [this.id]);
+};
+
+/**
+ * Get duration of an audio file.
+ * The duration is only set for audio that is playing, paused or stopped.
+ *
+ * @return      duration or -1 if not known.
+ */
+Media.prototype.getDuration = function() {
+    return this._duration;
+};
+
+/**
+ * Get position of audio.
+ */
+Media.prototype.getCurrentPosition = function(success, fail) {
+    var me = this;
+    exec(function(p) {
+        me._position = p;
+        success(p);
+    }, fail, "Media", "getCurrentPositionAudio", [this.id]);
+};
+
+/**
+ * Start recording audio file.
+ */
+Media.prototype.startRecord = function() {
+    exec(null, this.errorCallback, "Media", "startRecordingAudio", [this.id, this.src]);
+};
+
+/**
+ * Stop recording audio file.
+ */
+Media.prototype.stopRecord = function() {
+    exec(null, this.errorCallback, "Media", "stopRecordingAudio", [this.id]);
+};
+
+/**
+ * Release the resources.
+ */
+Media.prototype.release = function() {
+    exec(null, this.errorCallback, "Media", "release", [this.id]);
+};
+
+/**
+ * Adjust the volume.
+ */
+Media.prototype.setVolume = function(volume) {
+    exec(null, null, "Media", "setVolume", [this.id, volume]);
+};
+
+/**
+ * Audio has status update.
+ * PRIVATE
+ *
+ * @param id            The media object id (string)
+ * @param msgType       The 'type' of update this is
+ * @param value         Use of value is determined by the msgType
+ */
+Media.onStatus = function(id, msgType, value) {
+
+    var media = mediaObjects[id];
+
+    if(media) {
+        switch(msgType) {
+            case Media.MEDIA_STATE :
+                media.statusCallback && media.statusCallback(value);
+                if(value == Media.MEDIA_STOPPED) {
+                    media.successCallback && media.successCallback();
+                }
+                break;
+            case Media.MEDIA_DURATION :
+                media._duration = value;
+                break;
+            case Media.MEDIA_ERROR :
+                media.errorCallback && media.errorCallback(value);
+                break;
+            case Media.MEDIA_POSITION :
+                media._position = Number(value);
+                break;
+            default :
+                console.error && console.error("Unhandled Media.onStatus :: " + msgType);
+                break;
+        }
+    }
+    else {
+         console.error && console.error("Received Media.onStatus callback for unknown media :: " + id);
+    }
+
+};
+
+module.exports = Media;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media/www/MediaError.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.media/www/MediaError.js
@@ -1,0 +1,57 @@
+cordova.define("org.apache.cordova.media.MediaError", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * This class contains information about any Media errors.
+*/
+/*
+ According to :: http://dev.w3.org/html5/spec-author-view/video.html#mediaerror
+ We should never be creating these objects, we should just implement the interface
+ which has 1 property for an instance, 'code'
+
+ instead of doing :
+    errorCallbackFunction( new MediaError(3,'msg') );
+we should simply use a literal :
+    errorCallbackFunction( {'code':3} );
+ */
+
+ var _MediaError = window.MediaError;
+
+
+if(!_MediaError) {
+    window.MediaError = _MediaError = function(code, msg) {
+        this.code = (typeof code != 'undefined') ? code : null;
+        this.message = msg || ""; // message is NON-standard! do not use!
+    };
+}
+
+_MediaError.MEDIA_ERR_NONE_ACTIVE    = _MediaError.MEDIA_ERR_NONE_ACTIVE    || 0;
+_MediaError.MEDIA_ERR_ABORTED        = _MediaError.MEDIA_ERR_ABORTED        || 1;
+_MediaError.MEDIA_ERR_NETWORK        = _MediaError.MEDIA_ERR_NETWORK        || 2;
+_MediaError.MEDIA_ERR_DECODE         = _MediaError.MEDIA_ERR_DECODE         || 3;
+_MediaError.MEDIA_ERR_NONE_SUPPORTED = _MediaError.MEDIA_ERR_NONE_SUPPORTED || 4;
+// TODO: MediaError.MEDIA_ERR_NONE_SUPPORTED is legacy, the W3 spec now defines it as below.
+// as defined by http://dev.w3.org/html5/spec-author-view/video.html#error-codes
+_MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED = _MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED || 4;
+
+module.exports = _MediaError;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.network-information/src/firefoxos/NetworkProxy.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.network-information/src/firefoxos/NetworkProxy.js
@@ -1,0 +1,99 @@
+cordova.define("org.apache.cordova.network-information.NetworkProxy", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/*
+  Network API overview: http://www.w3.org/TR/netinfo-api/
+  and http://w3c.github.io/netinfo/
+*/
+
+var cordova = require('cordova'),
+    Connection = require('./Connection'),
+    modulemapper = require('cordova/modulemapper');
+
+var origConnection = modulemapper.getOriginalSymbol(window, 'navigator.connection');
+
+module.exports = {
+
+  getConnectionInfo: function(successCallback, errorCallback) {
+    var connection = origConnection || navigator.mozConnection,
+        connectionType = Connection.UNKNOWN;
+
+    if (!connection) {
+        setTimeout(function() {
+            successCallback(connectionType);
+        }, 0);
+        return;
+    }
+
+    var bandwidth = connection.bandwidth,
+      metered = connection.metered,
+      type = connection.type;
+
+    if (type != undefined) {
+      // For more information see:
+      // https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API
+
+      switch(type) {
+        case "cellular":
+          connectionType = Connection.CELL;
+          break;
+        case "ethernet":
+          connectionType = Connection.ETHERNET;
+          break;
+        case "wifi":
+          connectionType = Connection.WIFI;
+          break;
+        case "none":
+          connectionType = Connection.NONE;
+          break;
+      }
+    } else if (bandwidth != undefined && metered != undefined) {
+      /*
+      bandwidth of type double, readonly
+      The user agent must set the value of the bandwidth attribute to:
+      0 if the user is currently offline;
+      Infinity if the bandwidth is unknown;
+      an estimation of the current bandwidth in MB/s (Megabytes per seconds)
+      available for communication with the browsing context active document's
+      domain.
+
+      For more information see:
+      https://developer.mozilla.org/en-US/docs/Web/API/Connection
+      */
+
+      if (bandwidth === 0) {
+        connectionType = Connection.NONE;
+      } else if (metered && isFinite(bandwidth)) {
+        connectionType = Connection.CELL;
+      } else if (!metered && isFinite(bandwidth)) {
+        connectionType = Connection.WIFI;
+      }
+    }
+
+    setTimeout(function() {
+      successCallback(connectionType);
+    }, 0);
+  }
+};
+
+require("cordova/exec/proxy").add("NetworkStatus", module.exports);
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.network-information/www/Connection.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.network-information/www/Connection.js
@@ -1,0 +1,36 @@
+cordova.define("org.apache.cordova.network-information.Connection", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * Network status
+ */
+module.exports = {
+        UNKNOWN: "unknown",
+        ETHERNET: "ethernet",
+        WIFI: "wifi",
+        CELL_2G: "2g",
+        CELL_3G: "3g",
+        CELL_4G: "4g",
+        CELL:"cellular",
+        NONE: "none"
+};
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.network-information/www/network.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.network-information/www/network.js
@@ -1,0 +1,91 @@
+cordova.define("org.apache.cordova.network-information.network", function(require, exports, module) { /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var exec = require('cordova/exec'),
+    cordova = require('cordova'),
+    channel = require('cordova/channel'),
+    utils = require('cordova/utils');
+
+// Link the onLine property with the Cordova-supplied network info.
+// This works because we clobber the navigator object with our own
+// object in bootstrap.js.
+if (typeof navigator != 'undefined') {
+    utils.defineGetter(navigator, 'onLine', function() {
+        return this.connection.type != 'none';
+    });
+}
+
+function NetworkConnection() {
+    this.type = 'unknown';
+}
+
+/**
+ * Get connection info
+ *
+ * @param {Function} successCallback The function to call when the Connection data is available
+ * @param {Function} errorCallback The function to call when there is an error getting the Connection data. (OPTIONAL)
+ */
+NetworkConnection.prototype.getInfo = function(successCallback, errorCallback) {
+    exec(successCallback, errorCallback, "NetworkStatus", "getConnectionInfo", []);
+};
+
+var me = new NetworkConnection();
+var timerId = null;
+var timeout = 500;
+
+channel.createSticky('onCordovaConnectionReady');
+channel.waitForInitialization('onCordovaConnectionReady');
+
+channel.onCordovaReady.subscribe(function() {
+    me.getInfo(function(info) {
+        me.type = info;
+        if (info === "none") {
+            // set a timer if still offline at the end of timer send the offline event
+            timerId = setTimeout(function(){
+                cordova.fireDocumentEvent("offline");
+                timerId = null;
+            }, timeout);
+        } else {
+            // If there is a current offline event pending clear it
+            if (timerId !== null) {
+                clearTimeout(timerId);
+                timerId = null;
+            }
+            cordova.fireDocumentEvent("online");
+        }
+
+        // should only fire this once
+        if (channel.onCordovaConnectionReady.state !== 2) {
+            channel.onCordovaConnectionReady.fire();
+        }
+    },
+    function (e) {
+        // If we can't get the network info we should still tell Cordova
+        // to fire the deviceready event.
+        if (channel.onCordovaConnectionReady.state !== 2) {
+            channel.onCordovaConnectionReady.fire();
+        }
+        console.log("Error initializing Network Connection: " + e);
+    });
+});
+
+module.exports = me;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.splashscreen/www/splashscreen.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.splashscreen/www/splashscreen.js
@@ -1,0 +1,35 @@
+cordova.define("org.apache.cordova.splashscreen.SplashScreen", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var exec = require('cordova/exec');
+
+var splashscreen = {
+    show:function() {
+        exec(null, null, "SplashScreen", "show", []);
+    },
+    hide:function() {
+        exec(null, null, "SplashScreen", "hide", []);
+    }
+};
+
+module.exports = splashscreen;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.statusbar/www/statusbar.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.statusbar/www/statusbar.js
@@ -1,0 +1,111 @@
+cordova.define("org.apache.cordova.statusbar.statusbar", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var exec = require('cordova/exec');
+
+var namedColors = {
+    "black": "#000000",
+    "darkGray": "#A9A9A9",
+    "lightGray": "#D3D3D3",
+    "white": "#FFFFFF",
+    "gray": "#808080",
+    "red": "#FF0000",
+    "green": "#00FF00",
+    "blue": "#0000FF",
+    "cyan": "#00FFFF",
+    "yellow": "#FFFF00",
+    "magenta": "#FF00FF",
+    "orange": "##FFA500",
+    "purple": "#800080",
+    "brown": "#A52A2A"
+};
+
+var StatusBar = {
+
+    isVisible: true,
+
+    overlaysWebView: function (doOverlay) {
+        exec(null, null, "StatusBar", "overlaysWebView", [doOverlay]);
+    },
+
+    styleDefault: function () {
+        // dark text ( to be used on a light background )
+        exec(null, null, "StatusBar", "styleDefault", []);
+    },
+
+    styleLightContent: function () {
+        // light text ( to be used on a dark background )
+        exec(null, null, "StatusBar", "styleLightContent", []);
+    },
+
+    styleBlackTranslucent: function () {
+        // #88000000 ? Apple says to use lightContent instead
+        exec(null, null, "StatusBar", "styleBlackTranslucent", []);
+    },
+
+    styleBlackOpaque: function () {
+        // #FF000000 ? Apple says to use lightContent instead
+        exec(null, null, "StatusBar", "styleBlackOpaque", []);
+    },
+
+    backgroundColorByName: function (colorname) {
+        return StatusBar.backgroundColorByHexString(namedColors[colorname]);
+    },
+
+    backgroundColorByHexString: function (hexString) {
+        if (hexString.charAt(0) !== "#") {
+            hexString = "#" + hexString;
+        }
+
+        if (hexString.length === 4) {
+            var split = hexString.split("");
+            hexString = "#" + split[1] + split[1] + split[2] + split[2] + split[3] + split[3];
+        }
+
+        exec(null, null, "StatusBar", "backgroundColorByHexString", [hexString]);
+    },
+
+    hide: function () {
+        exec(null, null, "StatusBar", "hide", []);
+        StatusBar.isVisible = false;
+    },
+
+    show: function () {
+        exec(null, null, "StatusBar", "show", []);
+        StatusBar.isVisible = true;
+    }
+
+};
+
+// prime it
+exec(function (res) {
+    if (typeof res == 'object') {
+        if (res.type == 'tap') {
+            cordova.fireWindowEvent('statusTap');
+        }
+    } else {
+        StatusBar.isVisible = res;
+    }
+}, null, "StatusBar", "_ready", []);
+
+module.exports = StatusBar;
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.vibration/src/firefoxos/VibrationProxy.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.vibration/src/firefoxos/VibrationProxy.js
@@ -1,0 +1,36 @@
+cordova.define("org.apache.cordova.vibration.VibrationProxy", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var cordova = require('cordova');
+
+module.exports = {
+
+    vibrate: function(success, fail, milliseconds) {
+        if (navigator.notification.vibrate) {
+            navigator.vibrate(milliseconds);
+        } else {
+            console.log ("cordova/plugin/firefoxos/vibration, vibrate API does not exist");
+        }
+    }
+};
+
+require("cordova/exec/proxy").add("Vibration", module.exports);
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.vibration/www/vibration.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.apache.cordova.vibration/www/vibration.js
@@ -1,0 +1,121 @@
+cordova.define("org.apache.cordova.vibration.notification", function(require, exports, module) { /*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var exec = require('cordova/exec');
+
+/**
+ * Provides access to the vibration mechanism on the device.
+ */
+
+module.exports = {
+
+    /**
+     * Vibrates the device for a given amount of time or for a given pattern or immediately cancels any ongoing vibrations (depending on the parameter).
+     *
+     * @param {Integer} param       The number of milliseconds to vibrate (if 0, cancels vibration)
+     *
+     *
+     * @param {Array of Integer} param    Pattern with which to vibrate the device.
+     *                                      Pass in an array of integers that
+     *                                      are the durations for which to
+     *                                      turn on or off the vibrator in
+     *                                      milliseconds. The FIRST value
+     *                                      indicates the
+     *                                      number of milliseconds for which
+     *                                      to keep the vibrator ON before
+     *                                      turning it off. The NEXT value indicates the
+     *                                      number of milliseconds for which
+     *                                      to keep the vibrator OFF before
+     *                                      turning it on. Subsequent values
+     *                                      alternate between durations in
+     *                                      milliseconds to turn the vibrator
+     *                                      off or to turn the vibrator on.
+     *                                      (if empty, cancels vibration)
+     */
+    vibrate: function(param) {
+
+        /* Aligning with w3c spec */
+        
+        //vibrate
+        if ((typeof param == 'number') && param != 0)
+            exec(null, null, "Vibration", "vibrate", [param]);
+
+        //vibrate with array ( i.e. vibrate([3000]) )
+        else if ((typeof param == 'object') && param.length == 1)
+        {
+            //cancel if vibrate([0])
+            if (param[0] == 0)
+                exec(null, null, "Vibration", "cancelVibration", []);
+
+            //else vibrate
+            else
+                exec(null, null, "Vibration", "vibrate", [param[0]]);
+        }
+
+        //vibrate with a pattern
+        else if ((typeof param == 'object') && param.length > 1)
+        {
+            var repeat = -1; //no repeat
+            exec(null, null, "Vibration", "vibrateWithPattern", [param, repeat]);
+        }
+
+        //cancel vibration (param = 0 or [])
+        else
+            exec(null, null, "Vibration", "cancelVibration", []);
+    },
+
+    /**
+     * Vibrates the device with a given pattern.
+     *
+     * @param {Array of Integer} pattern    Pattern with which to vibrate the device.
+     *                                      Pass in an array of integers that
+     *                                      are the durations for which to
+     *                                      turn on or off the vibrator in
+     *                                      milliseconds. The first value
+     *                                      indicates the number of milliseconds
+     *                                      to wait before turning the vibrator
+     *                                      on. The next value indicates the
+     *                                      number of milliseconds for which
+     *                                      to keep the vibrator on before
+     *                                      turning it off. Subsequent values
+     *                                      alternate between durations in
+     *                                      milliseconds to turn the vibrator
+     *                                      off or to turn the vibrator on.
+     *
+     * @param {Integer} repeat              Optional index into the pattern array at which
+     *                                      to start repeating (will repeat until canceled),
+     *                                      or -1 for no repetition (default).
+     */
+    vibrateWithPattern: function(pattern, repeat) {
+        repeat = (typeof repeat !== "undefined") ? repeat : -1;
+        pattern.unshift(0); //add a 0 at beginning for backwards compatibility from w3c spec
+        exec(null, null, "Vibration", "vibrateWithPattern", [pattern, repeat]);
+    },
+
+    /**
+     * Immediately cancels any currently running vibration.
+     */
+    cancelVibration: function() {
+        exec(null, null, "Vibration", "cancelVibration", []);
+    },
+};
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.chromium.zip/tests/tests.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.chromium.zip/tests/tests.js
@@ -1,0 +1,80 @@
+cordova.define("org.chromium.zip.tests", function(require, exports, module) { exports.init = function() {
+  eval(require('org.apache.cordova.test-framework.test').injectJasmineInterface(this, 'this'));
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 75000;
+
+  var zip = require('org.chromium.zip.Zip');
+
+  describe('Zip', function () {
+    var fail = function(done, why) {
+      if (typeof why !== 'undefined') {
+        console.error(why);
+      }
+      expect(true).toBe(false);
+      done();
+    };
+
+    describe("unzip", function() {
+      it("should be defined", function() {
+        expect(typeof zip.unzip).toBeDefined();
+      });
+
+      var fileUrl = null;
+      var dirUrl = null;
+
+      it("downloading zip file", function(done) {
+        window.requestFileSystem  = window.requestFileSystem || window.webkitRequestFileSystem;
+        var onError = fail.bind(null, done);
+
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', 'http://archive.apache.org/dist/cordova/cordova-2.9.1-src.zip', true);
+        xhr.responseType = 'blob';
+        xhr.onerror = onError;
+        xhr.onprogress = console.log.bind(console);
+        xhr.onload = function(e) {
+
+          window.requestFileSystem(PERSISTENT, 1024 * 1024, function(fs) {
+            fs.root.getFile('cordova-2.9.1-src.zip', {create: true}, function(fileEntry) {
+              fileEntry.createWriter(function(writer) {
+
+                writer.onwrite = done;
+                writer.onerror = onError;
+
+                var blob = new Blob([xhr.response]);
+                writer.write(blob);
+                fileUrl = fileEntry.toNativeURL();
+              }, onError);
+            }, onError);
+
+            fs.root.getDirectory('zipOutput', {create: true}, function(fileEntry) {
+              dirUrl = fileEntry.toNativeURL();
+            }, onError);
+          }, onError);
+        };
+
+        xhr.send();
+      });
+
+      it("should unzip", function(done) {
+        zip.unzip(fileUrl, dirUrl, function(result) {
+          expect(result).toBe(0);
+          done();
+        });
+      });
+
+      it("should have progress events", function(done) {
+        var progress = 0;
+        zip.unzip(fileUrl, dirUrl, function(result) {
+          expect(result).toBe(0);
+          expect(progress).toBe(1.0);
+          done();
+        }, function(progressEvent) {
+          progress = progressEvent.loaded / progressEvent.total;
+          console.log(progress);
+        });
+      });
+    });
+  });
+};
+
+
+});

--- a/res/middleware/cordova/3.6.3/firefoxos/plugins/org.chromium.zip/zip.js
+++ b/res/middleware/cordova/3.6.3/firefoxos/plugins/org.chromium.zip/zip.js
@@ -1,0 +1,28 @@
+cordova.define("org.chromium.zip.Zip", function(require, exports, module) { var exec = cordova.require('cordova/exec');
+
+function newProgressEvent(result) {
+    var event = {
+            loaded: result.loaded,
+            total: result.total
+    };
+    return event;
+}
+
+exports.unzip = function(fileName, outputDirectory, callback, progressCallback) {
+    var win = function(result) {
+        if (result && typeof result.loaded != "undefined") {
+            if (progressCallback) {
+                return progressCallback(newProgressEvent(result));
+            }
+        } else if (callback) {
+            callback(0);
+        }
+    };
+    var fail = function(result) {
+        if (callback) {
+            callback(-1);
+        }
+    };
+    exec(win, fail, 'Zip', 'unzip', [fileName, outputDirectory]);
+};
+});


### PR DESCRIPTION
_Follow up from https://github.com/phonegap/connect-phonegap/pull/89_

Hi @mwbrooks,

This is a new version of the patch, rebased, made into a single commit and with `query.version` change removed as requested. Started a new PR because that other one was from master.

I started looking into adding zip deploy support for Firefox OS too. To get it working I added the CORS headers middleware here and I also needed to make a fix to our file plugin implementation. Next I need to add fxos support to org.chromium.zip. It may take a while to get all dependencies released and in good shape, but I kept the CORS change here as it's harmless to other platforms. Happy to remove from this PR if needed.

Thanks!
