### PR TITLE
Switch from gaze to chokidar.

### DIFF
--- a/lib/middleware/autoreload.js
+++ b/lib/middleware/autoreload.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 
-var gaze = require('gaze'),
+var chokidar = require('chokidar'),
     path = require('path');
 
 /**
@@ -27,7 +27,7 @@ module.exports = function(options) {
 
     // enable AutoReload
     if (options.autoreload) {
-        var watch = new gaze.Gaze(watches);
+        var watch = chokidar.watch(watches);
 
         watch.on('error', function(e) {
             if (options.emitter) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "connect": "2.12.0",
     "connect-inject": "0.3.2",
     "findit": "2.0.0",
-    "gaze": "0.4.3",
+    "chokidar": "1.0.1",
     "home-dir": "0.1.2",
     "http-proxy": "1.8.1",
     "ip": "0.3.1",


### PR DESCRIPTION
Hey there.

This commits switches `gaze` to a better file watcher, chokidar.

To summarize: chokidar is *much* more stable, and is super fast on OSX, with less CPU usage because of `fsevents`. Gaze has over 45 open issues. Just check their GH page.

Chokidar has been downloaded over 1.2M times last month and is used by very popular projects.