### PR TITLE
[#114] Add push state support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Options:
   - `[options]` {Object}
   - `[autoreload]` {Boolean} toggle AutoReload watch (default: true).
   - `[localtunnel]` {Boolean} toggle localtunnel (default: false).
+  - `[pushState]` {Boolean} toggle pushState (default: true)
 
 Events:
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -15,6 +15,7 @@ var autoreload = require('./middleware/autoreload'),
     path = require('path'),
     plugins = require('./middleware/cordova/plugins'),
     proxy = require('./middleware/proxy'),
+    pushState = require('./middleware/push_state'),
     register = require('./middleware/register');
 
 /**
@@ -101,6 +102,9 @@ module.exports = function(options) {
 
     // serve plugins if 404'd out from previous static server
     app.use(plugins(options));
+
+    // serve index.html when no other middleware fulfills the request
+    app.use(pushState(options));
 
     // create request listener and attach event emitter interface
     var requestListener = function(req, res, next) {

--- a/lib/middleware/push_state.js
+++ b/lib/middleware/push_state.js
@@ -1,0 +1,25 @@
+/*!
+ * Module dependencies.
+ */
+var fs = require('fs');
+var path = require('path');
+
+/**
+ * Push state asset middleware.
+ *
+ * Serves the index.html file. Should be used as the last middleware,
+ * when no other middleware completes the request
+ */
+
+module.exports = function(options) {
+    if(options.pushState === false) {
+      return function(req, res, next) {
+        next();
+      }
+    }
+
+    return function(req, res, next) {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      fs.createReadStream(path.join(process.cwd(), 'www', 'index.html'), 'utf-8').pipe(res);
+    }
+};

--- a/spec/middleware/push_state.spec.js
+++ b/spec/middleware/push_state.spec.js
@@ -1,0 +1,77 @@
+/*!
+ * Module dependencies.
+ */
+
+var chdir = require('chdir'),
+    events = require('events'),
+    gaze = require('gaze'),
+    phonegap = require('../../lib'),
+    request = require('supertest'),
+    watchSpy;
+
+
+/*!
+ * Specification: pushstate middleware
+ */
+
+describe('push state middleware', function() {
+    beforeEach(function() {
+        watchSpy = new events.EventEmitter();
+        spyOn(gaze, 'Gaze').andReturn(watchSpy);
+    });
+
+    describe('options', function() {
+        describe('push state', function() {
+            it('should be enabled by default', function() {
+                phonegap();
+                expect(gaze.Gaze).toHaveBeenCalled();
+            });
+
+            it('should be enabled when true', function() {
+                phonegap({ pushState: true });
+                expect(gaze.Gaze).toHaveBeenCalled();
+            });
+
+            it('should be disabled when false', function() {
+                phonegap({ pushState: false });
+                expect(gaze.Gaze).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('phonegap.serve', function() {
+        beforeEach(function() {
+            spyOn(http, 'createServer').andReturn({
+                on: function() {},
+                listen: function() {},
+                listeners:function(){return []},
+                removeAllListeners:function(){}
+            });
+        });
+
+        it('should pass the autoreload option', function() {
+            phonegap.serve({ pushState: true });
+            expect(gaze.Gaze).toHaveBeenCalled();
+        });
+    });
+
+
+    it('should serve index file on non-existent url', function(done) {
+        chdir('spec/fixture/app-without-cordova', function() {
+            request(phonegap()).get('/does-not-exist').end(function(e, res) {
+                expect(res.statusCode).toEqual(200);
+                expect(res.text).toMatch('<title>Hello World</title>');
+                done();
+            });
+        });
+    });
+
+    it('should not serve index file on non-existent url when disabled', function(done) {
+        chdir('spec/fixture/app-without-cordova', function() {
+            request(phonegap({pushState: false})).get('/does-not-exist').end(function(e, res) {
+                expect(res.statusCode).toEqual(404);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
To accomodate apps that leverage the History API, support for serving the
default page when no matching file is found on the file system.
This commit enables that by adding a new `pushState` middleware, that serves
the `index.html` page when no other middleware reponds to the request.
It is enabled by default, but can be disabled by setting the `pushState`
option to `false`. When disabled, the middleware changes to a simple pass-
through.
