### PR TITLE
[RFC] Follow symlink when zipping

### DIFF
--- a/lib/middleware/zip.js
+++ b/lib/middleware/zip.js
@@ -74,7 +74,7 @@ module.exports = function(options) {
             res.writeHead(200, { 'Content-Type': 'application/zip' } );
             archive.pipe(res);
 
-            var theWalker = walk(path.join(process.cwd(), 'www'));
+            var theWalker = walk(path.join(process.cwd(), 'www'), { "follow_symlinks": true });
 
             theWalker.on('file', function(filename){
                 var output = filename.split(process.cwd())[1];


### PR DESCRIPTION
Add follow symlink to walker options thus allowing to serve phonegap projects created with `--link-to` for www assets