### PR TITLE
Error message on zip error. Don't write header.

### DIFF
--- a/lib/middleware/zip.js
+++ b/lib/middleware/zip.js
@@ -67,7 +67,8 @@ module.exports = function(options) {
             var archive = archiver('zip', { store: false });
 
             archive.on('error', function(err) {
-                res.writeHead(500, { 'Content-Type': 'text/plain' });
+                console.error('Error, could not complete to zip up the app:');
+                console.error(err.stack);
                 res.end();
             });
 


### PR DESCRIPTION
This small change fixes my error in https://github.com/phonegap/connect-phonegap/issues/126 and shows a more useful error.

On the app-side itself it still shows a 'Download error': `Could not properly unzip the archive.` So that should still be fine.