### PR TITLE
Handle symlinks in zip output filenames

### DIFF
--- a/lib/middleware/zip.js
+++ b/lib/middleware/zip.js
@@ -67,6 +67,7 @@ module.exports = function(options) {
             var archive = archiver('zip', { store: false });
 
             archive.on('error', function(err) {
+                console.log(err);
                 res.writeHead(500, { 'Content-Type': 'text/plain' });
                 res.end();
             });
@@ -74,10 +75,12 @@ module.exports = function(options) {
             res.writeHead(200, { 'Content-Type': 'application/zip' } );
             archive.pipe(res);
 
-            var theWalker = walk(path.join(process.cwd(), 'www'), { 'follow_symlinks': true });
+            var wwwPath = fs.realpathSync(path.join(process.cwd(), 'www'));
+            var theWalker = walk(wwwPath, { 'follow_symlinks': false });
 
             theWalker.on('file', function(filename){
-                var output = filename.split(process.cwd())[1];
+                filename = fs.realpathSync(filename);
+                var output = path.join('/www', filename.split(wwwPath)[1]);
 
                 if (path.extname(filename) === '.html') {
                     var htmlStreamFile = fs.createReadStream(filename);


### PR DESCRIPTION
Fix issue #128 
This fixes the root cause for this problem https://github.com/phonegap/phonegap-app-developer/issues/299 and also adds logging in the zip error handler.