### PR TITLE
Be defensive when running as the browser platform

### DIFF
--- a/res/middleware/push.js
+++ b/res/middleware/push.js
@@ -5,19 +5,22 @@
 (function() {
 
     document.addEventListener('deviceready', function() {
-        var oldPushNotification = window.PushNotification;
-        window.PushNotification.init = function(options) {
-            if (options.android) {
-                options.android.senderID = "85075801930";
-                options.android.icon = "pushicon";
-                options.android.iconColor = "blue";
-            }
-            var pgdevPush = new oldPushNotification.PushNotification(options);
-            pgdevPush.on('registration', function(data) {
-                console.log('Device Push ID: \n' + data.registrationId);
-            });
-            return pgdevPush;
-        };
+        var oldPushNotification;
+        if (window.PushNotification) {
+            oldPushNotification = window.PushNotification;
+            window.PushNotification.init = function(options) {
+                if (options.android) {
+                    options.android.senderID = "85075801930";
+                    options.android.icon = "pushicon";
+                    options.android.iconColor = "blue";
+                }
+                var pgdevPush = new oldPushNotification.PushNotification(options);
+                pgdevPush.on('registration', function(data) {
+                    console.log('Device Push ID: \n' + data.registrationId);
+                });
+                return pgdevPush;
+            };
+        }
     });
 
 })(window);


### PR DESCRIPTION
`window.PushNotification.init` doesn't exist when running in the browser
platform. If youdon't check for it, it throws an error in the console.