### PR TITLE
Fixed console logging to accept multiple params

### DIFF
--- a/res/middleware/consoler-http.js
+++ b/res/middleware/consoler-http.js
@@ -4,25 +4,25 @@
     window.console = {
         log:function(){
             if(previousConsole.log) {
-                previousConsole.log.apply(this, arguments);
+                previousConsole.log.apply(previousConsole, arguments);
             }
             socket.emit('console','log', Array.prototype.slice.call(arguments).join('\t'));
         },
         warn:function(){
             if(previousConsole.warn) {
-                previousConsole.warn.apply(this, arguments);
+                previousConsole.warn.apply(previousConsole, arguments);
             }
             socket.emit('console','warn', Array.prototype.slice.call(arguments).join('\t'));
         },
         error:function(){
             if(previousConsole.error) {
-                previousConsole.error.apply(this, arguments);
+                previousConsole.error.apply(previousConsole, arguments);
             }
             socket.emit('console','error', Array.prototype.slice.call(arguments).join('\t'));
         },
         assert:function(assertion) {
             if(previousConsole.assert) {
-                previousConsole.assert.apply(this, arguments);
+                previousConsole.assert.apply(previousConsole, arguments);
             }
             if(assertion){
                 socket.emit('console','assert', Array.prototype.slice.call(arguments, 1).join('\t'));

--- a/res/middleware/consoler-http.js
+++ b/res/middleware/consoler-http.js
@@ -2,22 +2,30 @@
     var socket = io('http://' + document.location.host);
     var previousConsole = window.console || {};
     window.console = {
-        log:function(msg){
-            previousConsole.log && previousConsole.log(msg);
-            socket.emit('console','log', msg);
+        log:function(){
+            if(previousConsole.log) {
+                previousConsole.log.apply(this, arguments);
+            }
+            socket.emit('console','log', Array.prototype.slice.call(arguments).join('\t'));
         },
-        warn:function(msg){
-            previousConsole.warn && previousConsole.warn(msg);
-            socket.emit('console','warn', msg);
+        warn:function(){
+            if(previousConsole.warn) {
+                previousConsole.warn.apply(this, arguments);
+            }
+            socket.emit('console','warn', Array.prototype.slice.call(arguments).join('\t'));
         },
-        error:function(msg){
-            previousConsole.error && previousConsole.error(msg);
-            socket.emit('console','error', msg);
+        error:function(){
+            if(previousConsole.error) {
+                previousConsole.error.apply(this, arguments);
+            }
+            socket.emit('console','error', Array.prototype.slice.call(arguments).join('\t'));
         },
-        assert:function(assertion, msg){
-            previousConsole.assert && previousConsole.assert(assertion, msg);
+        assert:function(assertion) {
+            if(previousConsole.assert) {
+                previousConsole.assert.apply(this, arguments);
+            }
             if(assertion){
-                socket.emit('console','assert', msg);
+                socket.emit('console','assert', Array.prototype.slice.call(arguments, 1).join('\t'));
             }
         }
     }

--- a/res/middleware/consoler.js
+++ b/res/middleware/consoler.js
@@ -1,32 +1,31 @@
-
 (function(window) {
     var socket = io('http://127.0.0.1:3000');
     var previousConsole = window.console || {};
     window.console = {
-        log:function(msg){
+        log:function(){
             if(previousConsole.log) {
-                previousConsole.log(msg);
+                previousConsole.log.apply(this, arguments);
             }
-            socket.emit('console','log', msg);
+            socket.emit('console','log', Array.prototype.slice.call(arguments).join('\t'));
         },
-        warn:function(msg){
+        warn:function(){
             if(previousConsole.warn) {
-                previousConsole.warn(msg);
+                previousConsole.warn.apply(this, arguments);
             }
-            socket.emit('console','warn', msg);
+            socket.emit('console','warn', Array.prototype.slice.call(arguments).join('\t'));
         },
-        error:function(msg){
+        error:function(){
             if(previousConsole.error) {
-                previousConsole.error(msg);
+                previousConsole.error.apply(this, arguments);
             }
-            socket.emit('console','error', msg);
+            socket.emit('console','error', Array.prototype.slice.call(arguments).join('\t'));
         },
-        assert:function(assertion, msg) {
+        assert:function(assertion) {
             if(previousConsole.assert) {
-                previousConsole.assert(assertion, msg);
+                previousConsole.assert.apply(this, arguments);
             }
             if(assertion){
-                socket.emit('console','assert', msg);
+                socket.emit('console','assert', Array.prototype.slice.call(arguments, 1).join('\t'));
             }
         }
     };

--- a/res/middleware/consoler.js
+++ b/res/middleware/consoler.js
@@ -4,25 +4,25 @@
     window.console = {
         log:function(){
             if(previousConsole.log) {
-                previousConsole.log.apply(this, arguments);
+                previousConsole.log.apply(previousConsole, arguments);
             }
             socket.emit('console','log', Array.prototype.slice.call(arguments).join('\t'));
         },
         warn:function(){
             if(previousConsole.warn) {
-                previousConsole.warn.apply(this, arguments);
+                previousConsole.warn.apply(previousConsole, arguments);
             }
             socket.emit('console','warn', Array.prototype.slice.call(arguments).join('\t'));
         },
         error:function(){
             if(previousConsole.error) {
-                previousConsole.error.apply(this, arguments);
+                previousConsole.error.apply(previousConsole, arguments);
             }
             socket.emit('console','error', Array.prototype.slice.call(arguments).join('\t'));
         },
         assert:function(assertion) {
             if(previousConsole.assert) {
-                previousConsole.assert.apply(this, arguments);
+                previousConsole.assert.apply(previousConsole, arguments);
             }
             if(assertion){
                 socket.emit('console','assert', Array.prototype.slice.call(arguments, 1).join('\t'));


### PR DESCRIPTION
console.log, console.warn, etc accept more than one parameter. Consoler broke that behavior. This PR fixes the bug.
+ updated `consoler-http.js` to the code style of `consoler.js`