### PR TITLE
Fixes #191: proxying to invalid url blows things up

### DIFF
--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -35,9 +35,14 @@ module.exports = function(options) {
             req.url = url;
             proxy.web(req, res, { target: targetHost },
                 function error(err, req, res) {
-                    options.emitter.emit('log', 'Proxy error for url: ' + url, error.message);
-                    res.writeHead(err.code || 500);
-                    res.end(error.message);
+                    options.emitter.emit('error', 'Proxy error for url: ' + url, err.message);
+                    // For connection errors, err.code will be a string like 'ENOTFOUND'
+                    // Let's ensure code is numeric and >= 100, as that is what
+                    // response's writeHead expects.
+                    // TODO: perhaps it would be best to return HTTP 502 in the
+                    // case that proxying fails?
+                    res.writeHead(err.code && typeof err.code == 'number' && err.code >= 100 ? err.code : 500);
+                    res.end(err.message);
                 });
         }
         else {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^3.12.2",
     "istanbul": "0.4.5",
     "jasmine": "2.5.3",
+    "rewire": "2.5.2",
     "supertest": "2.0.0"
   },
   "contributors": [

--- a/spec/middleware/proxy.spec.js
+++ b/spec/middleware/proxy.spec.js
@@ -5,18 +5,20 @@
 var chdir = require('chdir'),
     gaze = require('gaze'),
     phonegap = require('../../lib'),
-    request = require('supertest');
+    request = require('supertest'),
+    rewire = require('rewire'),
+    middleware = rewire('../../lib/middleware/proxy'),
+    proxy, revert, web_spy, emit_spy, req;
 
 /*!
  * Specification: Proxy middleware.
  */
 
 describe('proxy middleware', function() {
-    beforeEach(function() {
-        spyOn(gaze, 'Gaze').and.returnValue({ on: function() {} });
-    });
-
     describe('single-origin request', function() {
+        beforeEach(function() {
+            spyOn(gaze, 'Gaze').and.returnValue({ on: function() {} });
+        });
         it('should be served normally', function(done) {
             chdir('spec/fixture/app-with-cordova', function() {
                 request(phonegap())
@@ -30,32 +32,64 @@ describe('proxy middleware', function() {
         });
     });
 
-    //
-    // better to mock the requests but this is awkward with request lib.
-    //
-    //describe('cross-origin request', function() {
-    //    it('should proxy http:', function(done) {
-    //        chdir('spec/fixture/app-with-cordova', function() {
-    //            request(phonegap())
-    //            .get('/proxy/http%3A%2F%2Fphonegap.com')
-    //            .end(function(e, res) {
-    //                expect(res.statusCode).toEqual(200);
-    //                expect(res.text).toMatch('PhoneGap');
-    //                done();
-    //            });
-    //        });
-    //    });
-
-    //    it('should proxy https:', function(done) {
-    //        chdir('spec/fixture/app-with-cordova', function() {
-    //            request(phonegap())
-    //            .get('/proxy/https%3A%2F%2Fajax.googleapis.com%2Fajax%2Fservices%2Fsearch%2Fweb%3Fv%3D1.0%26q%3DAdobe%2520PhoneGap')
-    //            .end(function(e, res) {
-    //                expect(res.statusCode).toEqual(200);
-    //                expect(res.text).toMatch('GsearchResultClass');
-    //                done();
-    //            });
-    //        });
-    //    });
-    //});
+    describe('cross-origin request', function() {
+        beforeEach(function() {
+            web_spy = jasmine.createSpy('proxy.web spy');
+            emit_spy = jasmine.createSpy('emitter spy');
+            revert = middleware.__set__('proxy', {
+                once:function() {},
+                web: web_spy
+            });
+            req = {
+                url: '/proxy/' + encodeURIComponent('http://phonegap.com/'),
+                headers: {
+                    host: '192.168.0.1'
+                }
+            };
+            proxy = middleware({
+                emitter: {
+                    emit: emit_spy
+                }
+            });
+        });
+        afterEach(function() {
+            revert();
+        });
+        it('should proxy http:', function() {
+            req.url = '/proxy/' + encodeURIComponent('http://phonegap.com/');
+            var res = {};
+            proxy(req, res);
+            expect(web_spy).toHaveBeenCalledWith(req, res, {target: 'http://phonegap.com'}, jasmine.any(Function));
+        });
+        it('should proxy https:', function() {
+            req.url = '/proxy/' + encodeURIComponent('https://phonegap.com/');
+            var res = {};
+            proxy(req, res);
+            expect(web_spy).toHaveBeenCalledWith(req, res, {target: 'https://phonegap.com'}, jasmine.any(Function));
+        });
+        it('should emit an error and return HTTP 500 for an invalid URL', function() {
+            // Revert rewire bits done in beforeEach
+            revert();
+            // Set up our own proxy.web spy so we can trigger the error flow
+            var err_msg = 'http://filmaj is an invalid url';
+            revert = middleware.__set__('proxy', {
+                once:function() {},
+                web: function(req, res, opts, cb) {
+                    cb({
+                        message: err_msg,
+                        code: 'ENOTFOUND'
+                    }, req, res);
+                }
+            });
+            req.url = '/proxy/' + encodeURIComponent('http://filmaj/');
+            var res = {
+                writeHead: jasmine.createSpy('res.writeHead'),
+                end: jasmine.createSpy('res.end')
+            };
+            proxy(req, res);
+            expect(emit_spy).toHaveBeenCalledWith('error', 'Proxy error for url: http://filmaj/', err_msg);
+            expect(res.writeHead).toHaveBeenCalledWith(500);
+            expect(res.end).toHaveBeenCalledWith(err_msg);
+        });
+    });
 });


### PR DESCRIPTION
Expanded tests for proxy middleware using rewire.
Fixed error object variable references in error flow.
Fixed proxy middleware response handling for connection errors, which include string-based error codes, which, if passed to `res.end`, blow things up. Be more defensive in the error case to ensure we pass an integer in the proper http status code range.

Please review / FYI @timkim @surajpindoria 