### PR TITLE
Use http-proxy changeOrigin option

### DIFF
--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -3,7 +3,7 @@
  */
 
 var httpProxy = require('http-proxy'),
-    proxy = new httpProxy.createProxyServer();
+    proxy = new httpProxy.createProxyServer({ changeOrigin: true });
 
 /**
  * Cross-Origin Requests Middleware.
@@ -20,7 +20,10 @@ var httpProxy = require('http-proxy'),
 module.exports = function(options) {
     return function(req, res, next) {
         if (req.url.indexOf('/__api__/proxy/') === 0 || req.url.indexOf('/proxy/') === 0) {
-            var url = decodeURIComponent(req.url.replace('/proxy/', '')),
+            var url = decodeURIComponent(req.url.replace(new RegExp('(/__api__)?/proxy/'), '')),
+                // TODO: what if the proxied URL has no trailing slash and is a
+                // top-level domain, e.g. http://phonegap.com ? the below will
+                // be undefined then.
                 targetHost = url.substring(0, url.indexOf('/', 8));
 
             //Re-Build the location header, so browsers can follow them
@@ -30,7 +33,6 @@ module.exports = function(options) {
             });
 
             req.url = url;
-            delete req.headers.host;
             proxy.web(req, res, { target: targetHost },
                 function error(err, req, res) {
                     options.emitter.emit('log', 'Proxy error for url: ' + url, error.message);


### PR DESCRIPTION
Closes #105. 
… instead of munging request headers ourselves.

Originally authored by @aleh and PR issued in https://github.com/phonegap/connect-phonegap/pull/105 - thank you!