### PR TITLE
Fixing proxy middleware w.r.t. redirect responses

### DIFF
--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -3,7 +3,11 @@
  */
 
 var httpProxy = require('http-proxy'),
-    proxy = new httpProxy.createProxyServer({ changeOrigin: true });
+    parse_url = require('url').parse,
+    proxy = new httpProxy.createProxyServer({
+        changeOrigin: true,
+        autoRewrite: true
+    });
 
 /**
  * Cross-Origin Requests Middleware.
@@ -20,16 +24,24 @@ var httpProxy = require('http-proxy'),
 module.exports = function(options) {
     return function(req, res, next) {
         if (req.url.indexOf('/__api__/proxy/') === 0 || req.url.indexOf('/proxy/') === 0) {
-            var url = decodeURIComponent(req.url.replace(new RegExp('(/__api__)?/proxy/'), '')),
-                // TODO: what if the proxied URL has no trailing slash and is a
-                // top-level domain, e.g. http://phonegap.com ? the below will
-                // be undefined then.
-                targetHost = url.substring(0, url.indexOf('/', 8));
+            var url = decodeURIComponent(req.url.replace(new RegExp('(/__api__)?/proxy/'), ''));
+            var parsed_url = parse_url(url);
+            var targetHost = parsed_url.protocol + '//' + parsed_url.host;
 
-            //Re-Build the location header, so browsers can follow them
+            // rebuild the location header, so browsers can follow them
             proxy.once('proxyRes', function (proxyRes, req, res) {
-                if (proxyRes.headers.location)
-                    proxyRes.headers.location = 'http://' + req.headers.host + '/proxy/' + targetHost + proxyRes.headers.location;
+                if (proxyRes.headers.location) {
+                    var parsed_location = parse_url(proxyRes.headers.location);
+                    var new_proxy_url;
+                    if (parsed_location.host) {
+                        new_proxy_url = parsed_location.href;
+                    } else {
+                        // if server responded with a relative/absolute url (no hostname),
+                        // fill in the hostname ourselves.
+                        new_proxy_url = targetHost + parsed_location.path;
+                    }
+                    proxyRes.headers.location = 'http://' + req.headers.host + '/proxy/' + encodeURIComponent(new_proxy_url);
+                }
             });
 
             req.url = url;

--- a/spec/middleware/proxy.spec.js
+++ b/spec/middleware/proxy.spec.js
@@ -7,8 +7,10 @@ var chdir = require('chdir'),
     phonegap = require('../../lib'),
     request = require('supertest'),
     rewire = require('rewire'),
+    http = require('http'),
     middleware = rewire('../../lib/middleware/proxy'),
-    proxy, revert, web_spy, emit_spy, req;
+    proxy, revert, web_spy, emit_spy, once_spy, req,
+    test_server;
 
 /*!
  * Specification: Proxy middleware.
@@ -36,8 +38,9 @@ describe('proxy middleware', function() {
         beforeEach(function() {
             web_spy = jasmine.createSpy('proxy.web spy');
             emit_spy = jasmine.createSpy('emitter spy');
+            once_spy = jasmine.createSpy('proxy.once spy');
             revert = middleware.__set__('proxy', {
-                once:function() {},
+                once: once_spy,
                 web: web_spy
             });
             req = {
@@ -90,6 +93,53 @@ describe('proxy middleware', function() {
             expect(emit_spy).toHaveBeenCalledWith('error', 'Proxy error for url: http://filmaj/', err_msg);
             expect(res.writeHead).toHaveBeenCalledWith(500);
             expect(res.end).toHaveBeenCalledWith(err_msg);
+        });
+    });
+    describe('integration test with a separate server', function() {
+        beforeEach(function() {
+            spyOn(gaze, 'Gaze').and.returnValue({ on: function() {} });
+        });
+        afterEach(function() {
+            test_server.close();
+        });
+        it('should handle redirects to different paths on the same server appropriately', function(done) {
+            test_server = http.createServer(function (req, res) {
+                if (req.url.match(/redirect/)) {
+                    res.writeHead(302, {
+                        'Location': '/gohereplz'
+                    });
+                } else {
+                    res.writeHead(200, { 'Content-Type': 'text/plain' });
+                    res.write('you have arrived');
+                }
+                res.end();
+            }).listen(9000);
+            chdir('spec/fixture/app-with-cordova', function() {
+                request(phonegap())
+                .get('/proxy/' + encodeURIComponent("http://localhost:9000/redirect"))
+                .end(function(e, res) {
+                    expect(res.statusCode).toEqual(302);
+                    expect(res.headers.location).toContain('/proxy/' + encodeURIComponent('http://localhost:9000/gohereplz'));
+                    done();
+                });
+            });
+        });
+        it('should handle redirects to different domains appropriately', function(done) {
+            test_server = http.createServer(function (req, res) {
+                res.writeHead(302, {
+                    'Location': 'http://phonegap.com/robots.txt'
+                });
+                res.end();
+            }).listen(9000);
+            chdir('spec/fixture/app-with-cordova', function() {
+                request(phonegap())
+                .get('/proxy/' + encodeURIComponent("http://localhost:9000/redirect"))
+                .end(function(e, res) {
+                    expect(res.statusCode).toEqual(302);
+                    expect(res.headers.location).toContain('/proxy/' + encodeURIComponent('http://phonegap.com/robots.txt'));
+                    done();
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
This fixes #197.

Also added tests that leverage a second HTTP server to better be able to control server responses when exercising the proxy middleware.