### PR TITLE
Using browser current protocol

### DIFF
--- a/res/middleware/autoreload-http.js
+++ b/res/middleware/autoreload-http.js
@@ -2,7 +2,7 @@
 // Reload the app if server detects local change
 //
 (function() {
-    var url = 'http://' + document.location.host + '/__api__/autoreload';
+    var url = document.location.protocol + '//' + document.location.host + '/__api__/autoreload';
 
     function postStatus() {
         var xhr = new XMLHttpRequest();

--- a/res/middleware/consoler-http.js
+++ b/res/middleware/consoler-http.js
@@ -1,5 +1,5 @@
 (function(window) {
-    var socket = io('http://' + document.location.host);
+    var socket = io(document.location.protocol + '//' + document.location.host);
 
     // Copy the functions to avoid stack overflow
     var previousConsole = Object.assign({}, window.console);


### PR DESCRIPTION
Hey,

I've added a simple fix that allows phonegap to run under HTTPS when HTTP is disabled for current domain