### PR TITLE
Fix #205 unexpectedly removing multiple substring occurences

### DIFF
--- a/lib/middleware/cordova/plugins.js
+++ b/lib/middleware/cordova/plugins.js
@@ -15,7 +15,7 @@ module.exports = function() {
     // return the request listener
     return function(req, res, next) {
         if (req.url.indexOf('plugins/') >= 0) {
-            var pluginPath = req.url.split('plugins/')[1];
+            var pluginPath = req.url.replace('plugins/', '');
             var filepath = path.join(
                 __dirname,
                 '../../../res/middleware/cordova',

--- a/lib/middleware/update.js
+++ b/lib/middleware/update.js
@@ -48,7 +48,7 @@ module.exports = function(options) {
 
             for (var i = lastUpdatedIndex; i < options.filesToUpdate.length; i++) {
                 var filename = options.filesToUpdate[i][1];
-                var output = filename.split(process.cwd())[1];
+                var output = filename.replace(process.cwd(), '');
 
                 if (path.extname(filename) === '.html') {
                     var htmlStreamFile = fs.createReadStream(filename);

--- a/lib/middleware/zip.js
+++ b/lib/middleware/zip.js
@@ -69,7 +69,7 @@ module.exports = function(options) {
                 });
 
                 theWalker.on('file', function(filename) {
-                    var output = pathWithSymlinks(filename).split(process.cwd())[1];
+                    var output = pathWithSymlinks(filename).replace(process.cwd(), '');
 
                     if (path.extname(filename) === '.html') {
                         var htmlStreamFile = fs.createReadStream(filename);


### PR DESCRIPTION
Use [`String.prototype.replace()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) to remove only the first occurence of the substring