### PR TITLE
Fixed updating multiple files with /__api__/update

### DIFF
--- a/lib/middleware/update.js
+++ b/lib/middleware/update.js
@@ -39,16 +39,22 @@ module.exports = function(options) {
             }
 
             // first find where the indices we need to update in options.filesToUpdate
-            var lastUpdatedIndex = 0;
+            var firstPendingIndex = options.filesToUpdate.length;
             for (var i = 0; i < options.filesToUpdate.length; i++) {
                 if (req.session.lastFlush < options.filesToUpdate[i][0]) {
-                    lastUpdatedIndex = i;
+                    firstPendingIndex = i;
+                    break;
                 }
             }
 
-            for (var i = lastUpdatedIndex; i < options.filesToUpdate.length; i++) {
+            var appendedFilenames = {};
+
+            for (var i = firstPendingIndex; i < options.filesToUpdate.length; i++) {
                 var filename = options.filesToUpdate[i][1];
                 var output = filename.replace(process.cwd(), '');
+                if (output in appendedFilenames)
+                    continue;
+                appendedFilenames[output] = true;
 
                 if (path.extname(filename) === '.html') {
                     var htmlStreamFile = fs.createReadStream(filename);

--- a/lib/middleware/update.js
+++ b/lib/middleware/update.js
@@ -68,7 +68,9 @@ module.exports = function(options) {
                 }
             }
 
-            req.session.lastFlush = Date.now();
+            if (req.method != 'HEAD') {
+                req.session.lastFlush = Date.now();
+            }
 
             archive.finalize();
         }


### PR DESCRIPTION
Seems like `/__api__/update` handling simultaneous updates of multiple files incorrectly. If `options.filesToUpdate` contains several files that are newer than `lastFlush`, it zippes only the last one and drops all other files.

May be I'm missing something, but what is the point of `lastUpdatedIndex`? Since `filesToUpdate` is always sorted by timestamps, if it contains any file that is newer than `lastFlush`, `lastUpdatedIndex` will _always_ be equal to `filesToUpdate.length-1`. Sounds like `break` is missing in the original code. But variable name sounds strange if so, and the default value that is set before `for` loop should be changed also.

This problem was masking another one: same file names can appear in `filesToUpdate` multiple times and we should guard against repeatedly appending same file to resulting zip or PhoneGap Developer app will fail to extract it.

Background:
My dev environment consists of `webpack --watch` producing output files into `www` folder which is served by `phonegap serve`. And it is _very_ annoying that phonegap's autoreloading were almost never able to send updates to the PhoneGap Developer app: when I change source files, app restarts content, but still uses old version of the code. The problem was because of webpack is writing all output files at once and PhoneGap's broken `/__api__/update` was unable to deliver all the updates to the app.