### PR TITLE
fix autoreload callback loop

### DIFF
--- a/res/middleware/autoreload-http.js
+++ b/res/middleware/autoreload-http.js
@@ -10,6 +10,7 @@
         xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
         xhr.onreadystatechange = function() {
             if (this.readyState === 4 && /^[2]/.test(this.status)) {
+                window.location.reload();
             }
         };
         xhr.send();
@@ -24,7 +25,6 @@
                 var response = JSON.parse(this.responseText);
                 if (response.content.outdated) {
                     postStatus();
-                    window.location.reload();
                 }
             }
         };


### PR DESCRIPTION
puts the .reload() call inside the callback of postStatus().
otherwise the reload is called before the statechange of the postStatus() XHR request, creating a loop.